### PR TITLE
Allow to pass a custom KaTeX renderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - lts/dubnium
   - node
+before_script: npm install katex
 after_script: bash <(curl -s https://codecov.io/bash)

--- a/packages/rehype-katex/package.json
+++ b/packages/rehype-katex/package.json
@@ -30,14 +30,16 @@
   "main": "index.js",
   "dependencies": {
     "hast-util-to-text": "^1.0.0",
-    "katex": "^0.10.0",
     "rehype-parse": "^6.0.0",
     "unified": "^8.0.0",
     "unist-util-visit": "^2.0.0"
   },
   "peerDependencies": {
-    "remark-math": ">=1.0.0"
+    "remark-math": ">=1.0.0",
+    "katex": ">=0.10.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "katex": "^0.10.0"
+  },
   "xo": false
 }

--- a/packages/rehype-katex/readme.md
+++ b/packages/rehype-katex/readme.md
@@ -16,8 +16,12 @@
 [npm][]:
 
 ```sh
+npm install katex
 npm install rehype-katex
 ```
+
+KaTeX is a [*peer dependency*](https://nodejs.org/en/blog/npm/peer-dependencies/) of
+this package, therefore, you will need it installed before using the plugin.
 
 ## Use
 
@@ -91,6 +95,20 @@ Use of `rehype-katex` renders user content with [KaTeX][], so any vulnerability
 in KaTeX can open you to a [cross-site scripting (XSS)][xss] attack.
 
 Always be wary of user input and use [`rehype-sanitize`][rehype-sanitize].
+
+## Plugins
+
+KaTeX uses globals to load it’s plugins.
+As KaTeX is a peer dependency of `rehype-katex`, you can load
+plugins very easily by simply requiring them.
+Here is an example for the `mhchem` extension:
+
+```javascript
+require('katex/dist/contrib/mhchem')
+```
+
+Loading can happen anytime in you code, but will be included for all
+the calls you make to the processor *after the require* instruction.
 
 ## Contribute
 

--- a/packages/rehype-katex/test.js
+++ b/packages/rehype-katex/test.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-unassigned-import */
 const test = require('tape')
 const katex = require('katex')
 const unified = require('unified')
@@ -202,6 +203,40 @@ test('rehype-katex', function(t) {
       )
       .toString(),
     'should support `strict: ignore`'
+  )
+
+  // Pregenerate a result without mhchem
+  const noMhchemResult = unified()
+    .use(parseHtml, {fragment: true, position: false})
+    .use(rehypeKatex)
+    .use(stringify)
+    .processSync(
+      [
+        '<p>mhchem plugin:</p>',
+        '<div class="math-display">\\ce{CO2 + C -> 2 CO}</div>'
+      ].join('\n')
+    )
+    .toString()
+
+  // Add mhchem to KaTeX
+  require('katex/dist/contrib/mhchem')
+
+  // Assert the results are differents with and without mhchem
+  t.notEqual(
+    noMhchemResult,
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(stringify)
+      .processSync(
+        [
+          '<p>mhchem plugin:</p>',
+          '<div class="math-display">' +
+            katex.renderToString('\\ce{CO2 + C -> 2 CO}', {displayMode: true}) +
+            '</div>'
+        ].join('\n')
+      )
+      .toString(),
+    'should allow plugins'
   )
 
   t.end()


### PR DESCRIPTION
# Context

We needed to use the new [*mhchem* plugin](https://github.com/KaTeX/KaTeX/pull/1436) for a renderer, but were not able to do it using `rehype-katex`, because the KaTeX basically have no support for dynamic loading, so it would have been needed to "embed" the plugin directly into this plugin, which seems to me like a bad idea.

# Resolution

I allow people to inject directly their KaTeX renderer inside of the plugin, so that they can load modules or anything.

# Example

How to use it:

```javascript
const katexWithPlugins = require("katex");
require("katex/dist/contrib/mhchem");

const unified = require("unified");
const remark = require("remark-parse");
const demath = require("remark-math");
const bridge = require("remark-rehype");
const sermath = require("rehype-katex");
const rehype = require("rehype-stringify");

unified()
	.use(remark)
	.use(demath)
	.use(bridge)
	.use(sermath, { katexRenderer: katexWithPlugins.renderToString })
	.use(rehype)
	.process("$\\ce{a A + b B -> c \\textbf{C} + d D}$", (e, vfile) => {
		console.log(String(vfile));
	});
```

# What remains?

Review should be quite easy to do, but publishing the package would be necessary; I see that it was not published recently, so maybe you were working on something @wooorm ?