### PR TITLE
Add support MathJax

### DIFF
--- a/packages/rehype-mathjax/browser-renderer.js
+++ b/packages/rehype-mathjax/browser-renderer.js
@@ -1,0 +1,23 @@
+const fromDom = require('hast-util-from-dom')
+const {mathjax} = require('mathjax-full/js/mathjax')
+const {TeX} = require('mathjax-full/js/input/tex')
+const {SVG} = require('mathjax-full/js/output/svg')
+const {browserAdaptor} = require('mathjax-full/js/adaptors/browserAdaptor')
+const {RegisterHTMLHandler} = require('mathjax-full/js/handlers/html')
+const {AllPackages} = require('mathjax-full/js/input/tex/AllPackages')
+
+const adaptor = browserAdaptor()
+Reflect.apply(RegisterHTMLHandler, null, [adaptor])
+const tex = new TeX({packages: AllPackages})
+const svg = new SVG({fontCache: 'none'})
+const mathDocument = mathjax.document('', {InputJax: tex, OutputJax: svg})
+const stylesheet = adaptor.textContent(svg.styleSheet(mathDocument))
+
+module.exports.stylesheet = () => ({
+  type: 'element',
+  tagName: 'style',
+  properties: {},
+  children: [{type: 'text', value: stylesheet}]
+})
+module.exports.render = (math, options) =>
+  fromDom(mathDocument.convert(math, options))

--- a/packages/rehype-mathjax/index.js
+++ b/packages/rehype-mathjax/index.js
@@ -1,0 +1,23 @@
+const visit = require('unist-util-visit')
+const toText = require('hast-util-to-text')
+const renderer = require('./renderer')
+
+module.exports = () => {
+  return (tree) => {
+    var found = false
+    visit(tree, 'element', (element) => {
+      const classes = element.properties.className || []
+      const inline = classes.includes('math-inline')
+      const display = classes.includes('math-display')
+      if (!inline && !display) {
+        return
+      }
+
+      found = true
+      element.children = [renderer.render(toText(element), {display})]
+    })
+    if (found) {
+      tree.children.push(renderer.stylesheet())
+    }
+  }
+}

--- a/packages/rehype-mathjax/package.json
+++ b/packages/rehype-mathjax/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "rehype-mathjax",
+  "version": "0.1.0",
+  "description": "rehype plugin to transform inline and block math with MathJax",
+  "license": "MIT",
+  "keywords": [
+    "unified",
+    "remark",
+    "rehype",
+    "rehype-plugin",
+    "plugin",
+    "mdast",
+    "markdown",
+    "hast",
+    "html",
+    "math",
+    "mathjax",
+    "latex",
+    "tex"
+  ],
+  "repository": "https://github.com/remarkjs/remark-math/tree/master/packages/rehype-mathjax",
+  "bugs": "https://github.com/remarkjs/remark-math/issues",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+  },
+  "browser": {
+    "./renderer": "./browser-renderer"
+  },
+  "author": "TANIGUCHI Masaya <taniguchi.masaya@yandex.com> (https://docs.casa)",
+  "files": [
+    "renderer.js",
+    "browser-renderer.js",
+    "index.js"
+  ],
+  "main": "index.js",
+  "dependencies": {
+    "hast-util-from-dom": "^2.0.5",
+    "hast-util-to-html": "^7.1.0",
+    "hast-util-to-text": "^2.0.0",
+    "jsdom": "^16.2.2",
+    "mathjax-full": "^3.0.5",
+    "unified": "^8.0.0",
+    "unist-util-visit": "^2.0.0"
+  },
+  "devDependencies": {},
+  "xo": false
+}

--- a/packages/rehype-mathjax/readme.md
+++ b/packages/rehype-mathjax/readme.md
@@ -1,0 +1,260 @@
+# rehype-mathjax
+
+[![Build][build-badge]][build]
+[![Coverage][coverage-badge]][coverage]
+[![Downloads][downloads-badge]][downloads]
+[![Size][size-badge]][size]
+[![Sponsors][sponsors-badge]][collective]
+[![Backers][backers-badge]][collective]
+[![Chat][chat-badge]][chat]
+
+[**rehype**][rehype] plugin to transform `<span class=math-inline>` and
+`<div class=math-display>` with [MathJax][].
+
+## Install
+
+[npm][]:
+
+```sh
+npm install rehype-mathjax
+```
+
+## Use
+
+Say we have the following file, `example.html`:
+
+```html
+<p>
+  Lift(<span class="math math-inline">L</span>) can be determined by Lift Coefficient
+  (<span class="math math-inline">C_L</span>) like the following equation.
+</p>
+
+<div class="math math-display">
+  L = \frac{1}{2} \rho v^2 S C_L
+</div>
+```
+
+And our script, `example.js`, looks as follows:
+
+```js
+const vfile = require('to-vfile')
+const unified = require('unified')
+const parse = require('rehype-parse')
+const mathjax = require('rehype-mathjax')
+const stringify = require('rehype-stringify')
+
+unified()
+  .use(parse, {fragment: true})
+  .use(mathjax)
+  .use(stringify)
+  .process(vfile.readSync('example.html'), function(err, file) {
+    if (err) throw err
+    console.log(String(file))
+  })
+```
+
+Now, running `node example` yields:
+
+```html
+<p>
+  Lift(<span class="math math-inline"><mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: 0;" xmlns="http://www.w3.org/2000/svg" width="1.541ex" height="1.545ex" role="img" focusable="false" viewBox="0 -683 681 683"><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><g data-mml-node="mi"><path data-c="1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"></path></g></g></g></svg></mjx-container></span>) can be determined by Lift Coefficient
+  (<span class="math math-inline"><mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.339ex;" xmlns="http://www.w3.org/2000/svg" width="2.82ex" height="1.934ex" role="img" focusable="false" viewBox="0 -705 1246.5 855"><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><g data-mml-node="msub"><g data-mml-node="mi"><path data-c="1D436" d="M50 252Q50 367 117 473T286 641T490 704Q580 704 633 653Q642 643 648 636T656 626L657 623Q660 623 684 649Q691 655 699 663T715 679T725 690L740 705H746Q760 705 760 698Q760 694 728 561Q692 422 692 421Q690 416 687 415T669 413H653Q647 419 647 422Q647 423 648 429T650 449T651 481Q651 552 619 605T510 659Q484 659 454 652T382 628T299 572T226 479Q194 422 175 346T156 222Q156 108 232 58Q280 24 350 24Q441 24 512 92T606 240Q610 253 612 255T628 257Q648 257 648 248Q648 243 647 239Q618 132 523 55T319 -22Q206 -22 128 53T50 252Z"></path></g><g data-mml-node="mi" transform="translate(715, -150) scale(0.707)"><path data-c="1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"></path></g></g></g></g></svg></mjx-container></span>) like the following equation.
+</p>
+
+<div class="math math-display"><mjx-container class="MathJax" jax="SVG" display="true"><svg style="vertical-align: -1.552ex;" xmlns="http://www.w3.org/2000/svg" width="14.144ex" height="4.588ex" role="img" focusable="false" viewBox="0 -1342 6251.6 2028"><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><g data-mml-node="mi"><path data-c="1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"></path></g><g data-mml-node="mo" transform="translate(958.8, 0)"><path data-c="3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path></g><g data-mml-node="mfrac" transform="translate(2014.6, 0)"><g data-mml-node="mn" transform="translate(220, 676)"><path data-c="31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path></g><g data-mml-node="mn" transform="translate(220, -686)"><path data-c="32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path></g><rect width="700" height="60" x="120" y="220"></rect></g><g data-mml-node="mi" transform="translate(2954.6, 0)"><path data-c="1D70C" d="M58 -216Q25 -216 23 -186Q23 -176 73 26T127 234Q143 289 182 341Q252 427 341 441Q343 441 349 441T359 442Q432 442 471 394T510 276Q510 219 486 165T425 74T345 13T266 -10H255H248Q197 -10 165 35L160 41L133 -71Q108 -168 104 -181T92 -202Q76 -216 58 -216ZM424 322Q424 359 407 382T357 405Q322 405 287 376T231 300Q217 269 193 170L176 102Q193 26 260 26Q298 26 334 62Q367 92 389 158T418 266T424 322Z"></path></g><g data-mml-node="msup" transform="translate(3471.6, 0)"><g data-mml-node="mi"><path data-c="1D463" d="M173 380Q173 405 154 405Q130 405 104 376T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Q21 294 29 316T53 368T97 419T160 441Q202 441 225 417T249 361Q249 344 246 335Q246 329 231 291T200 202T182 113Q182 86 187 69Q200 26 250 26Q287 26 319 60T369 139T398 222T409 277Q409 300 401 317T383 343T365 361T357 383Q357 405 376 424T417 443Q436 443 451 425T467 367Q467 340 455 284T418 159T347 40T241 -11Q177 -11 139 22Q102 54 102 117Q102 148 110 181T151 298Q173 362 173 380Z"></path></g><g data-mml-node="mn" transform="translate(485, 413) scale(0.707)"><path data-c="32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path></g></g><g data-mml-node="mi" transform="translate(4360.1, 0)"><path data-c="1D446" d="M308 24Q367 24 416 76T466 197Q466 260 414 284Q308 311 278 321T236 341Q176 383 176 462Q176 523 208 573T273 648Q302 673 343 688T407 704H418H425Q521 704 564 640Q565 640 577 653T603 682T623 704Q624 704 627 704T632 705Q645 705 645 698T617 577T585 459T569 456Q549 456 549 465Q549 471 550 475Q550 478 551 494T553 520Q553 554 544 579T526 616T501 641Q465 662 419 662Q362 662 313 616T263 510Q263 480 278 458T319 427Q323 425 389 408T456 390Q490 379 522 342T554 242Q554 216 546 186Q541 164 528 137T492 78T426 18T332 -20Q320 -22 298 -22Q199 -22 144 33L134 44L106 13Q83 -14 78 -18T65 -22Q52 -22 52 -14Q52 -11 110 221Q112 227 130 227H143Q149 221 149 216Q149 214 148 207T144 186T142 153Q144 114 160 87T203 47T255 29T308 24Z"></path></g><g data-mml-node="msub" transform="translate(5005.1, 0)"><g data-mml-node="mi"><path data-c="1D436" d="M50 252Q50 367 117 473T286 641T490 704Q580 704 633 653Q642 643 648 636T656 626L657 623Q660 623 684 649Q691 655 699 663T715 679T725 690L740 705H746Q760 705 760 698Q760 694 728 561Q692 422 692 421Q690 416 687 415T669 413H653Q647 419 647 422Q647 423 648 429T650 449T651 481Q651 552 619 605T510 659Q484 659 454 652T382 628T299 572T226 479Q194 422 175 346T156 222Q156 108 232 58Q280 24 350 24Q441 24 512 92T606 240Q610 253 612 255T628 257Q648 257 648 248Q648 243 647 239Q618 132 523 55T319 -22Q206 -22 128 53T50 252Z"></path></g><g data-mml-node="mi" transform="translate(715, -150) scale(0.707)"><path data-c="1D43F" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 217 683Q271 680 344 680Q485 680 506 683H518Q524 677 524 674T522 656Q517 641 513 637H475Q406 636 394 628Q387 624 380 600T313 336Q297 271 279 198T252 88L243 52Q243 48 252 48T311 46H328Q360 46 379 47T428 54T478 72T522 106T564 161Q580 191 594 228T611 270Q616 273 628 273H641Q647 264 647 262T627 203T583 83T557 9Q555 4 553 3T537 0T494 -1Q483 -1 418 -1T294 0H116Q32 0 32 10Q32 17 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"></path></g></g></g></g></svg></mjx-container></div>
+
+<style>
+mjx-container[jax="SVG"] {
+  direction: ltr;
+}
+
+mjx-container[jax="SVG"] > svg {
+  overflow: visible;
+}
+
+mjx-container[jax="SVG"] > svg a {
+  fill: blue;
+  stroke: blue;
+}
+
+mjx-container[jax="SVG"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+mjx-container[jax="SVG"][display="true"][width="full"] {
+  display: flex;
+}
+
+mjx-container[jax="SVG"][justify="left"] {
+  text-align: left;
+}
+
+mjx-container[jax="SVG"][justify="right"] {
+  text-align: right;
+}
+
+g[data-mml-node="merror"] > g {
+  fill: red;
+  stroke: red;
+}
+
+g[data-mml-node="merror"] > rect[data-background] {
+  fill: yellow;
+  stroke: none;
+}
+
+g[data-mml-node="mtable"] > line[data-line] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > rect[data-frame] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > .mjx-dashed {
+  stroke-dasharray: 140;
+}
+
+g[data-mml-node="mtable"] > .mjx-dotted {
+  stroke-linecap: round;
+  stroke-dasharray: 0,140;
+}
+
+g[data-mml-node="mtable"] > g > svg {
+  overflow: visible;
+}
+
+[jax="SVG"] mjx-tool {
+  display: inline-block;
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+[jax="SVG"] mjx-tool > mjx-tip {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+mjx-tool > mjx-tip {
+  display: inline-block;
+  padding: .2em;
+  border: 1px solid #888;
+  font-size: 70%;
+  background-color: #F8F8F8;
+  color: black;
+  box-shadow: 2px 2px 5px #AAAAAA;
+}
+
+g[data-mml-node="maction"][data-toggle] {
+  cursor: pointer;
+}
+
+mjx-status {
+  display: block;
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+  min-width: 25%;
+  padding: .2em .4em;
+  border: 1px solid #888;
+  font-size: 90%;
+  background-color: #F8F8F8;
+  color: black;
+}
+
+foreignObject[data-mjx-xml] {
+  font-family: initial;
+  line-height: normal;
+  overflow: visible;
+}
+
+.MathJax path {
+  stroke-width: 3;
+}
+</style>
+```
+
+## API
+
+### `rehype().use(mathjax)`
+
+Transform `<span class="math-inline">` and `<div class="math-display">` with
+[MathJax][].
+
+## Security
+
+Use of `rehype-mathjax` renders user content with [MathJax][],
+so any vulnerability in MathJax can open you
+to a [cross-site scripting (XSS)][xss] attack.
+
+Always be wary of user input and use [`rehype-sanitize`][rehype-sanitize].
+
+## Contribute
+
+See [`contributing.md`][contributing] in [`remarkjs/.github`][health] for ways
+to get started.
+See [`support.md`][support] for ways to get help.
+
+This project has a [code of conduct][coc].
+By interacting with this repository, organization, or community you agree to
+abide by its terms.
+
+## License
+
+[MIT][license] © [TANIGUCHI Masaya][author]
+
+<!-- Definitions -->
+
+[build-badge]: https://img.shields.io/travis/remarkjs/remark-math/master.svg
+
+[build]: https://travis-ci.org/remarkjs/remark-math
+
+[coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark-math.svg
+
+[coverage]: https://codecov.io/github/remarkjs/remark-math
+
+[downloads-badge]: https://img.shields.io/npm/dm/rehype-mathjax.svg
+
+[downloads]: https://www.npmjs.com/package/rehype-mathjax
+
+[size-badge]: https://img.shields.io/bundlephobia/minzip/rehype-mathjax.svg
+
+[size]: https://bundlephobia.com/result?p=rehype-mathjax
+
+[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
+
+[backers-badge]: https://opencollective.com/unified/backers/badge.svg
+
+[collective]: https://opencollective.com/unified
+
+[chat-badge]: https://img.shields.io/badge/chat-spectrum-7b16ff.svg
+
+[chat]: https://spectrum.chat/unified/remark
+
+[npm]: https://docs.npmjs.com/cli/install
+
+[health]: https://github.com/remarkjs/.github
+
+[contributing]: https://github.com/remarkjs/.github/blob/master/contributing.md
+
+[support]: https://github.com/remarkjs/.github/blob/master/support.md
+
+[coc]: https://github.com/remarkjs/.github/blob/master/code-of-conduct.md
+
+[license]: https://github.com/remarkjs/remark-math/blob/master/license
+
+[author]: https://rokt33r.github.io
+
+[rehype]: https://github.com/rehypejs/rehype
+
+[xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
+
+[rehype-sanitize]: https://github.com/rehypejs/rehype-sanitize
+
+[mathjax]: https://mathjax.org/

--- a/packages/rehype-mathjax/renderer.js
+++ b/packages/rehype-mathjax/renderer.js
@@ -1,0 +1,24 @@
+const fromDom = require('hast-util-from-dom')
+const {JSDOM} = require('jsdom')
+const {mathjax} = require('mathjax-full/js/mathjax')
+const {TeX} = require('mathjax-full/js/input/tex')
+const {SVG} = require('mathjax-full/js/output/svg')
+const {jsdomAdaptor} = require('mathjax-full/js/adaptors/jsdomAdaptor')
+const {RegisterHTMLHandler} = require('mathjax-full/js/handlers/html')
+const {AllPackages} = require('mathjax-full/js/input/tex/AllPackages')
+
+const adaptor = jsdomAdaptor(JSDOM)
+Reflect.apply(RegisterHTMLHandler, null, [adaptor])
+const tex = new TeX({packages: AllPackages})
+const svg = new SVG({fontCache: 'none'})
+const mathDocument = mathjax.document('', {InputJax: tex, OutputJax: svg})
+const stylesheet = adaptor.textContent(svg.styleSheet(mathDocument))
+
+module.exports.stylesheet = () => ({
+  type: 'element',
+  tagName: 'style',
+  properties: {},
+  children: [{type: 'text', value: stylesheet}]
+})
+module.exports.render = (math, options) =>
+  fromDom(mathDocument.convert(math, options))

--- a/packages/rehype-mathjax/test.js
+++ b/packages/rehype-mathjax/test.js
@@ -1,0 +1,121 @@
+const test = require('tape')
+const renderer = require('./renderer')
+const unified = require('unified')
+const parseMarkdown = require('remark-parse')
+const remark2rehype = require('remark-rehype')
+const parseHtml = require('rehype-parse')
+const stringify = require('rehype-stringify')
+const math = require('../remark-math')
+const rehypeMathjax = require('.')
+const toHtml = require('hast-util-to-html')
+
+test('rehype-mathjax', function (t) {
+  t.deepEqual(
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(rehypeMathjax)
+      .use(stringify)
+      .processSync(
+        [
+          '<p>Inline math <span class="math-inline">\\alpha</span>.</p>',
+          '<p>Block math:</p>',
+          '<div class="math-display">\\gamma</div>'
+        ].join('\n')
+      )
+      .toString(),
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(stringify)
+      .processSync(
+        [
+          '<p>Inline math <span class="math-inline">' +
+            toHtml(renderer.render('\\alpha', {display: false})) +
+            '</span>.</p>',
+          '<p>Block math:</p>',
+          '<div class="math-display">' +
+            toHtml(renderer.render('\\gamma', {display: true})) +
+            '</div>' +
+            toHtml(renderer.stylesheet())
+        ].join('\n')
+      )
+      .toString(),
+    'should transform math with mathjax'
+  )
+
+  t.deepEqual(
+    unified()
+      .use(parseMarkdown, {position: false})
+      .use(math)
+      .use(remark2rehype)
+      .use(rehypeMathjax)
+      .use(stringify)
+      .processSync(
+        [
+          'Inline math $\\alpha$.',
+          '',
+          'Block math:',
+          '',
+          '$$',
+          '\\gamma',
+          '$$'
+        ].join('\n')
+      )
+      .toString(),
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(stringify)
+      .processSync(
+        [
+          '<p>Inline math <span class="math math-inline">' +
+            toHtml(renderer.render('\\alpha', {display: false})) +
+            '</span>.</p>',
+          '<p>Block math:</p>',
+          '<div class="math math-display">' +
+            toHtml(renderer.render('\\gamma', {display: true})) +
+            '</div>' +
+            toHtml(renderer.stylesheet())
+        ].join('\n')
+      )
+      .toString(),
+    'should integrate with `remark-math`'
+  )
+
+  t.deepEqual(
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(rehypeMathjax)
+      .use(stringify)
+      .processSync(
+        '<p>Double math <span class="math-inline math-display">\\alpha</span>.</p>'
+      )
+      .toString(),
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(stringify)
+      .processSync(
+        '<p>Double math <span class="math-inline math-display">' +
+          toHtml(renderer.render('\\alpha', {display: true})) +
+          '</span>.</p>' +
+          toHtml(renderer.stylesheet())
+      )
+      .toString(),
+    'should transform `.math-inline.math-display` math with `displayMode: true`'
+  )
+
+  t.deepEqual(
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(rehypeMathjax)
+      .use(stringify)
+      .processSync('<p>No math</p>')
+      .toString(),
+    unified()
+      .use(parseHtml, {fragment: true, position: false})
+      .use(stringify)
+      .processSync('<p>No math</p>')
+      .toString(),
+    'Should not be insert stylesheet if it is no math'
+  )
+
+  t.end()
+})

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,8 @@ This repo houses three packages:
 *   [`rehype-katex`][rehype-katex]
     — Transforms math nodes with [KaTeX][]
     (recommended)
+*   [`rehype-mathjax`][rehype-mathjax]
+    — Transforms math nodes with [MathJax][]
 *   [`remark-html-katex`][remark-html-katex]
     — Transforms math nodes with [KaTeX][] for [`remark-html`][remark-html]
     (discouraged)
@@ -176,11 +178,15 @@ abide by its terms.
 
 [katex]: https://github.com/Khan/KaTeX
 
+[mathjax]: https://mathjax.org/
+
 [xss]: https://en.wikipedia.org/wiki/Cross-site_scripting
 
 [remark-math]: ./packages/remark-math
 
 [rehype-katex]: ./packages/rehype-katex
+
+[rehype-mathjax]: ./packages/rehype-mathjax
 
 [remark-html-katex]: ./packages/remark-html-katex
 


### PR DESCRIPTION
Hi there,

Thank you for great plugin! As I want to use MathJaX instead of KaTeX in this plugin, I create this request. This plugin insert SVG and its stylesheet to each nodes, that SVG is generated by MathJax v3.

Cheers!