### PR TITLE
katex: update min version of `katex`

### DIFF
--- a/packages/rehype-katex/package.json
+++ b/packages/rehype-katex/package.json
@@ -35,7 +35,7 @@
   "main": "index.js",
   "dependencies": {
     "hast-util-to-text": "^2.0.0",
-    "katex": "^0.11.0",
+    "katex": "^0.12.0",
     "rehype-parse": "^6.0.0",
     "unified": "^9.0.0",
     "unist-util-visit": "^2.0.0"


### PR DESCRIPTION
Some breaking changes were introduced in katex 0.12.0, see e.g. KaTeX/KaTeX#2347. In particular, the css files for 0.12.0 aren't compatible with the output of `rehype-katex`. The tests still pass after bumping the version.