### PR TITLE
rehype-mathjax: allow configuration of the TeX input processor

### DIFF
--- a/packages/rehype-mathjax/browser.js
+++ b/packages/rehype-mathjax/browser.js
@@ -1,6 +1,14 @@
 const createPlugin = require('./lib/core')
 
-module.exports = createPlugin('rehypeMathJaxBrowser', renderBrowser)
+module.exports = createPlugin(
+  'rehypeMathJaxBrowser',
+  renderBrowser,
+  false,
+  true
+)
+
+/* To do next major: Make `options` match the format of MathJax options
+`{tex: ...}` */
 
 function renderBrowser(options) {
   const settings = options || {}

--- a/packages/rehype-mathjax/chtml.d.ts
+++ b/packages/rehype-mathjax/chtml.d.ts
@@ -16,6 +16,28 @@ interface MathJaxCHtmlOptions {
   adaptiveCSS?: boolean
 }
 
-declare const renderCHtml: Plugin<[MathJaxCHtmlOptions]>
+// http://docs.mathjax.org/en/latest/options/input/tex.html#the-configuration-block
+interface MathJaxInputTexOptions {
+  packages: string[]
+  inlineMath: [[string, string]]
+  displayMath: [[string, string]]
+  processEscapes: boolean
+  processEnvironments: boolean
+  processRefs: boolean
+  digits: RegExp
+  tags: 'none' | 'ams' | 'all'
+  tagSide: 'left' | 'right'
+  tagIndent: string
+  useLabelIds: boolean
+  multlineWidth: string
+  maxMacros: number
+  maxBuffer: number
+  baseURL: string
+  formatError: (jax: any, err: any) => string
+}
+
+declare const renderCHtml: Plugin<
+  [MathJaxCHtmlOptions & {tex?: Partial<MathJaxInputTexOptions>}]
+>
 
 export = renderCHtml

--- a/packages/rehype-mathjax/chtml.js
+++ b/packages/rehype-mathjax/chtml.js
@@ -5,6 +5,6 @@ const createPlugin = require('./lib/core')
 
 module.exports = createPlugin('rehypeMathJaxCHtml', renderCHtml, true)
 
-function renderCHtml(options) {
-  return createRenderer(createInput(options.tex), createOutput(options))
+function renderCHtml(inputOptions, outputOptions) {
+  return createRenderer(createInput(inputOptions), createOutput(outputOptions))
 }

--- a/packages/rehype-mathjax/chtml.js
+++ b/packages/rehype-mathjax/chtml.js
@@ -3,8 +3,8 @@ const createOutput = require('./lib/output-chtml')
 const createRenderer = require('./lib/renderer')
 const createPlugin = require('./lib/core')
 
-module.exports = createPlugin('rehypeMathJaxCHtml', renderCHtml)
+module.exports = createPlugin('rehypeMathJaxCHtml', renderCHtml, true)
 
 function renderCHtml(options) {
-  return createRenderer(createInput((options || {}).tex), createOutput(options))
+  return createRenderer(createInput(options.tex), createOutput(options))
 }

--- a/packages/rehype-mathjax/chtml.js
+++ b/packages/rehype-mathjax/chtml.js
@@ -6,5 +6,5 @@ const createPlugin = require('./lib/core')
 module.exports = createPlugin('rehypeMathJaxCHtml', renderCHtml)
 
 function renderCHtml(options) {
-  return createRenderer(createInput(), createOutput(options))
+  return createRenderer(createInput((options || {}).tex), createOutput(options))
 }

--- a/packages/rehype-mathjax/index.d.ts
+++ b/packages/rehype-mathjax/index.d.ts
@@ -19,8 +19,30 @@ interface MathJaxSvgOptions {
   titleID: number
 }
 
+// http://docs.mathjax.org/en/latest/options/input/tex.html#the-configuration-block
+interface MathJaxInputTexOptions {
+  packages: string[]
+  inlineMath: [[string, string]]
+  displayMath: [[string, string]]
+  processEscapes: boolean
+  processEnvironments: boolean
+  processRefs: boolean
+  digits: RegExp
+  tags: 'none' | 'ams' | 'all'
+  tagSide: 'left' | 'right'
+  tagIndent: string
+  useLabelIds: boolean
+  multlineWidth: string
+  maxMacros: number
+  maxBuffer: number
+  baseURL: string
+  formatError: (jax: any, err: any) => string
+}
+
 type RenderSVGOptions = Partial<MathJaxSvgOptions>
 
-declare const renderSvg: Plugin<[RenderSVGOptions?]>
+declare const renderSvg: Plugin<
+  [(RenderSVGOptions & {tex?: Partial<MathJaxInputTexOptions>})?]
+>
 
 export = renderSvg

--- a/packages/rehype-mathjax/lib/core.js
+++ b/packages/rehype-mathjax/lib/core.js
@@ -2,19 +2,25 @@ const visit = require('unist-util-visit')
 
 module.exports = createPlugin
 
-function createPlugin(displayName, createRenderer) {
+function createPlugin(displayName, createRenderer, chtml = false) {
   attacher.displayName = displayName
 
   return attacher
 
   function attacher(options) {
-    const renderer = createRenderer(options)
+    if (chtml && (!options || !options.fontURL)) {
+      throw new Error(
+        'rehype-mathjax: missing `fontURL` in options, which must be set to a URL to reach MathJaX fonts'
+      )
+    }
 
     transform.displayName = displayName + 'Transform'
 
     return transform
 
     function transform(tree) {
+      const renderer = createRenderer(options)
+
       let context = tree
       let found = false
 

--- a/packages/rehype-mathjax/lib/core.js
+++ b/packages/rehype-mathjax/lib/core.js
@@ -2,7 +2,10 @@ const visit = require('unist-util-visit')
 
 module.exports = createPlugin
 
-function createPlugin(displayName, createRenderer, chtml = false) {
+/* To do next major: Remove `chtml` and `browser` flags once all the options use
+the same format */
+
+function createPlugin(displayName, createRenderer, chtml, browser) {
   attacher.displayName = displayName
 
   return attacher
@@ -14,12 +17,19 @@ function createPlugin(displayName, createRenderer, chtml = false) {
       )
     }
 
+    const inputOptions = browser ? options : (options || {}).tex
+    let outputOptions = options || {}
+    if ('tex' in outputOptions) {
+      outputOptions = Object.assign({}, outputOptions)
+      delete outputOptions.tex
+    }
+
     transform.displayName = displayName + 'Transform'
 
     return transform
 
     function transform(tree) {
-      const renderer = createRenderer(options)
+      const renderer = createRenderer(inputOptions, outputOptions)
 
       let context = tree
       let found = false

--- a/packages/rehype-mathjax/lib/input.js
+++ b/packages/rehype-mathjax/lib/input.js
@@ -4,5 +4,5 @@ const packages = require('mathjax-full/js/input/tex/AllPackages').AllPackages
 module.exports = createInput
 
 function createInput(options) {
-  return new Tex({packages: packages, ...options})
+  return new Tex(Object.assign({packages: packages}, options))
 }

--- a/packages/rehype-mathjax/lib/input.js
+++ b/packages/rehype-mathjax/lib/input.js
@@ -3,6 +3,6 @@ const packages = require('mathjax-full/js/input/tex/AllPackages').AllPackages
 
 module.exports = createInput
 
-function createInput() {
-  return new Tex({packages: packages})
+function createInput(options) {
+  return new Tex({packages: packages, ...options})
 }

--- a/packages/rehype-mathjax/lib/output-chtml.js
+++ b/packages/rehype-mathjax/lib/output-chtml.js
@@ -9,5 +9,11 @@ function createOutput(options) {
     )
   }
 
-  return new CHtml(options)
+  let settings = options
+  if ('tex' in settings) {
+    settings = {...options}
+    delete settings.tex
+  }
+
+  return new CHtml(settings)
 }

--- a/packages/rehype-mathjax/lib/output-chtml.js
+++ b/packages/rehype-mathjax/lib/output-chtml.js
@@ -3,11 +3,5 @@ const CHtml = require('mathjax-full/js/output/chtml').CHTML
 module.exports = createOutput
 
 function createOutput(options) {
-  let settings = options
-  if ('tex' in settings) {
-    settings = {...options}
-    delete settings.tex
-  }
-
-  return new CHtml(settings)
+  return new CHtml(options)
 }

--- a/packages/rehype-mathjax/lib/output-chtml.js
+++ b/packages/rehype-mathjax/lib/output-chtml.js
@@ -3,12 +3,6 @@ const CHtml = require('mathjax-full/js/output/chtml').CHTML
 module.exports = createOutput
 
 function createOutput(options) {
-  if (!options || !options.fontURL) {
-    throw new Error(
-      'rehype-mathjax: missing `fontURL` in options, which must be set to a URL to reach MathJaX fonts'
-    )
-  }
-
   let settings = options
   if ('tex' in settings) {
     settings = {...options}

--- a/packages/rehype-mathjax/lib/output-svg.js
+++ b/packages/rehype-mathjax/lib/output-svg.js
@@ -3,11 +3,5 @@ const Svg = require('mathjax-full/js/output/svg').SVG
 module.exports = createOutput
 
 function createOutput(options) {
-  let settings = options || {}
-  if ('tex' in settings) {
-    settings = {...options}
-    delete settings.tex
-  }
-
-  return new Svg(settings)
+  return new Svg(options)
 }

--- a/packages/rehype-mathjax/lib/output-svg.js
+++ b/packages/rehype-mathjax/lib/output-svg.js
@@ -3,5 +3,11 @@ const Svg = require('mathjax-full/js/output/svg').SVG
 module.exports = createOutput
 
 function createOutput(options) {
-  return new Svg(options)
+  let settings = options || {}
+  if ('tex' in settings) {
+    settings = {...options}
+    delete settings.tex
+  }
+
+  return new Svg(settings)
 }

--- a/packages/rehype-mathjax/lib/renderer.js
+++ b/packages/rehype-mathjax/lib/renderer.js
@@ -6,10 +6,10 @@ const createAdaptor = require('./adaptor')
 
 module.exports = renderer
 
-function renderer(input, output) {
-  const adaptor = createAdaptor()
-  register(adaptor)
+const adaptor = createAdaptor()
+register(adaptor)
 
+function renderer(input, output) {
   const doc = mathjax.document('', {InputJax: input, OutputJax: output})
 
   return {render: render, styleSheet: styleSheet}

--- a/packages/rehype-mathjax/readme.md
+++ b/packages/rehype-mathjax/readme.md
@@ -112,6 +112,11 @@ Options are not passed to MathJax: do that yourself on the client.
 
 All options, except when using the browser plugin, are passed to
 [MathJax][mathjax-options].
+Specifically, they are passed to the chosen output processor.
+
+#### `options.tex`
+
+These options are passed to the [TeX input processor][mathjax-tex-options].
 
 ## Security
 
@@ -190,3 +195,5 @@ abide by its terms.
 [mathjax-svg]: http://docs.mathjax.org/en/latest/output/svg.html
 
 [mathjax-chtml]: http://docs.mathjax.org/en/latest/output/html.html
+
+[mathjax-tex-options]: http://docs.mathjax.org/en/latest/options/input/tex.html

--- a/packages/rehype-mathjax/svg.js
+++ b/packages/rehype-mathjax/svg.js
@@ -5,6 +5,6 @@ const createPlugin = require('./lib/core')
 
 module.exports = createPlugin('rehypeMathJaxSvg', renderSvg)
 
-function renderSvg(options) {
-  return createRenderer(createInput((options || {}).tex), createOutput(options))
+function renderSvg(inputOptions, outputOptions) {
+  return createRenderer(createInput(inputOptions), createOutput(outputOptions))
 }

--- a/packages/rehype-mathjax/svg.js
+++ b/packages/rehype-mathjax/svg.js
@@ -6,5 +6,5 @@ const createPlugin = require('./lib/core')
 module.exports = createPlugin('rehypeMathJaxSvg', renderSvg)
 
 function renderSvg(options) {
-  return createRenderer(createInput(), createOutput(options))
+  return createRenderer(createInput((options || {}).tex), createOutput(options))
 }

--- a/packages/rehype-mathjax/test.ts
+++ b/packages/rehype-mathjax/test.ts
@@ -7,11 +7,15 @@ import browser from 'rehype-mathjax/browser'
 unified().use(mathjax)
 // $ExpectType Processor<Settings>
 unified().use(mathjax, {minScale: 3})
+// $ExpectType Processor<Settings>
+unified().use(mathjax, {minScale: 3, tex: {tags: 'ams'}})
 // $ExpectError
 unified().use(mathjax, {invalidProp: true})
 
 // $ExpectType Processor<Settings>
 unified().use(chtml, {fontURL: 'url'})
+// $ExpectType Processor<Settings>
+unified().use(chtml, {fontURL: 'url', tex: {tags: 'ams'}})
 // $ExpectError
 unified().use(chtml)
 // $ExpectError

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
@@ -1,0 +1,742 @@
+<p>Block math:</p>
+<div class="math-display"><mjx-container class="MathJax" jax="CHTML" display="true" width="full" style="min-width: 7.968em;"><mjx-math width="full" display="true" class="MJX-TEX"><mjx-mtable width="full" style="min-width: 7.968em;" side="right"><mjx-table style="width: auto; min-width: 3.812em; margin: 0px 2.078em;"><mjx-itable width="full"><mjx-mlabeledtr><mjx-mtd><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D438 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c3D"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="4"><mjx-c class="mjx-c1D45A TEX-I"></mjx-c></mjx-mi><mjx-msup><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D450 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: 0.413em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c32"></mjx-c></mjx-mn></mjx-script></mjx-msup><mjx-tstrut></mjx-tstrut></mjx-mtd></mjx-mlabeledtr></mjx-itable></mjx-table><mjx-labels style="width: 7.968em;"><mjx-itable align="right" style="right: 0px;"><mjx-mtr style="height: 1.134em;"><mjx-mtd id="mjx-eqn-mass-energy_relation"><mjx-mtext class="mjx-n"><mjx-c class="mjx-c28"></mjx-c><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c29"></mjx-c></mjx-mtext><mjx-tstrut style="height: 1.134em; vertical-align: -0.25em;"></mjx-tstrut></mjx-mtd></mjx-mtr></mjx-itable></mjx-labels></mjx-mtable></mjx-math></mjx-container></div>
+<p>See equation <span class="math-inline"><mjx-container class="MathJax" jax="CHTML"><mjx-math class="MJX-TEX"><a href="#mjx-eqn-mass-energy_relation"><mjx-mrow class="MathJax_ref"><mjx-mtext class="mjx-n"><mjx-c class="mjx-c28"></mjx-c><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c29"></mjx-c></mjx-mtext></mjx-mrow></a></mjx-math></mjx-container></span>.</p>
+<style>
+mjx-container[jax="CHTML"] {
+  line-height: 0;
+}
+
+mjx-container [space="1"] {
+  margin-left: .111em;
+}
+
+mjx-container [space="2"] {
+  margin-left: .167em;
+}
+
+mjx-container [space="3"] {
+  margin-left: .222em;
+}
+
+mjx-container [space="4"] {
+  margin-left: .278em;
+}
+
+mjx-container [space="5"] {
+  margin-left: .333em;
+}
+
+mjx-container [rspace="1"] {
+  margin-right: .111em;
+}
+
+mjx-container [rspace="2"] {
+  margin-right: .167em;
+}
+
+mjx-container [rspace="3"] {
+  margin-right: .222em;
+}
+
+mjx-container [rspace="4"] {
+  margin-right: .278em;
+}
+
+mjx-container [rspace="5"] {
+  margin-right: .333em;
+}
+
+mjx-container [size="s"] {
+  font-size: 70.7%;
+}
+
+mjx-container [size="ss"] {
+  font-size: 50%;
+}
+
+mjx-container [size="Tn"] {
+  font-size: 60%;
+}
+
+mjx-container [size="sm"] {
+  font-size: 85%;
+}
+
+mjx-container [size="lg"] {
+  font-size: 120%;
+}
+
+mjx-container [size="Lg"] {
+  font-size: 144%;
+}
+
+mjx-container [size="LG"] {
+  font-size: 173%;
+}
+
+mjx-container [size="hg"] {
+  font-size: 207%;
+}
+
+mjx-container [size="HG"] {
+  font-size: 249%;
+}
+
+mjx-container [width="full"] {
+  width: 100%;
+}
+
+mjx-box {
+  display: inline-block;
+}
+
+mjx-block {
+  display: block;
+}
+
+mjx-itable {
+  display: inline-table;
+}
+
+mjx-row {
+  display: table-row;
+}
+
+mjx-row > * {
+  display: table-cell;
+}
+
+mjx-mtext {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-mstyle {
+  display: inline-block;
+}
+
+mjx-merror {
+  display: inline-block;
+  color: red;
+  background-color: yellow;
+}
+
+mjx-mphantom {
+  visibility: hidden;
+}
+
+mjx-math {
+  display: inline-block;
+  text-align: left;
+  line-height: 0;
+  text-indent: 0;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 100%;
+  font-size-adjust: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  word-spacing: normal;
+  white-space: nowrap;
+  direction: ltr;
+  padding: 1px 0;
+}
+
+mjx-container[jax="CHTML"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+mjx-container[jax="CHTML"][display="true"][width="full"] {
+  display: flex;
+}
+
+mjx-container[jax="CHTML"][display="true"] mjx-math {
+  padding: 0;
+}
+
+mjx-container[jax="CHTML"][justify="left"] {
+  text-align: left;
+}
+
+mjx-container[jax="CHTML"][justify="right"] {
+  text-align: right;
+}
+
+mjx-mrow {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-inferredMrow {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-mi {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-mo {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-stretchy-h {
+  display: inline-table;
+  width: 100%;
+}
+
+mjx-stretchy-h > * {
+  display: table-cell;
+  width: 0;
+}
+
+mjx-stretchy-h > * > mjx-c {
+  display: inline-block;
+  transform: scalex(1.0000001);
+}
+
+mjx-stretchy-h > * > mjx-c::before {
+  display: inline-block;
+  padding: .001em 0;
+  width: initial;
+}
+
+mjx-stretchy-h > mjx-ext {
+  overflow: hidden;
+  width: 100%;
+}
+
+mjx-stretchy-h > mjx-ext > mjx-c::before {
+  transform: scalex(500);
+}
+
+mjx-stretchy-h > mjx-ext > mjx-c {
+  width: 0;
+}
+
+mjx-stretchy-h > mjx-beg > mjx-c {
+  margin-right: -.1em;
+}
+
+mjx-stretchy-h > mjx-end > mjx-c {
+  margin-left: -.1em;
+}
+
+mjx-stretchy-v {
+  display: inline-block;
+}
+
+mjx-stretchy-v > * {
+  display: block;
+}
+
+mjx-stretchy-v > mjx-beg {
+  height: 0;
+}
+
+mjx-stretchy-v > mjx-end > mjx-c {
+  display: block;
+}
+
+mjx-stretchy-v > * > mjx-c {
+  transform: scaley(1.0000001);
+  transform-origin: left center;
+  overflow: hidden;
+}
+
+mjx-stretchy-v > mjx-ext {
+  display: block;
+  height: 100%;
+  box-sizing: border-box;
+  border: 0px solid transparent;
+  overflow: hidden;
+}
+
+mjx-stretchy-v > mjx-ext > mjx-c::before {
+  width: initial;
+}
+
+mjx-stretchy-v > mjx-ext > mjx-c {
+  transform: scaleY(500) translateY(.1em);
+  overflow: visible;
+}
+
+mjx-mark {
+  display: inline-block;
+  height: 0px;
+}
+
+mjx-mn {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-msup {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-mover {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-mover:not([limits="false"]) {
+  padding-top: .1em;
+}
+
+mjx-mover:not([limits="false"]) > * {
+  display: block;
+  text-align: left;
+}
+
+mjx-mtable {
+  display: inline-block;
+  text-align: center;
+  vertical-align: .25em;
+  position: relative;
+  box-sizing: border-box;
+}
+
+mjx-labels {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+mjx-table {
+  display: inline-block;
+  vertical-align: -.5ex;
+}
+
+mjx-table > mjx-itable {
+  vertical-align: middle;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+mjx-labels > mjx-itable {
+  position: absolute;
+  top: 0;
+}
+
+mjx-mtable[justify="left"] {
+  text-align: left;
+}
+
+mjx-mtable[justify="right"] {
+  text-align: right;
+}
+
+mjx-mtable[justify="left"][side="left"] {
+  padding-right: 0 ! important;
+}
+
+mjx-mtable[justify="left"][side="right"] {
+  padding-left: 0 ! important;
+}
+
+mjx-mtable[justify="right"][side="left"] {
+  padding-right: 0 ! important;
+}
+
+mjx-mtable[justify="right"][side="right"] {
+  padding-left: 0 ! important;
+}
+
+mjx-mtable[align] {
+  vertical-align: baseline;
+}
+
+mjx-mtable[align="top"] > mjx-table {
+  vertical-align: top;
+}
+
+mjx-mtable[align="bottom"] > mjx-table {
+  vertical-align: bottom;
+}
+
+mjx-mtable[side="right"] mjx-labels {
+  min-width: 100%;
+}
+
+mjx-mtr {
+  display: table-row;
+  text-align: left;
+}
+
+mjx-mtr[rowalign="top"] > mjx-mtd {
+  vertical-align: top;
+}
+
+mjx-mtr[rowalign="center"] > mjx-mtd {
+  vertical-align: middle;
+}
+
+mjx-mtr[rowalign="bottom"] > mjx-mtd {
+  vertical-align: bottom;
+}
+
+mjx-mtr[rowalign="baseline"] > mjx-mtd {
+  vertical-align: baseline;
+}
+
+mjx-mtr[rowalign="axis"] > mjx-mtd {
+  vertical-align: .25em;
+}
+
+mjx-mlabeledtr {
+  display: table-row;
+  text-align: left;
+}
+
+mjx-mlabeledtr[rowalign="top"] > mjx-mtd {
+  vertical-align: top;
+}
+
+mjx-mlabeledtr[rowalign="center"] > mjx-mtd {
+  vertical-align: middle;
+}
+
+mjx-mlabeledtr[rowalign="bottom"] > mjx-mtd {
+  vertical-align: bottom;
+}
+
+mjx-mlabeledtr[rowalign="baseline"] > mjx-mtd {
+  vertical-align: baseline;
+}
+
+mjx-mlabeledtr[rowalign="axis"] > mjx-mtd {
+  vertical-align: .25em;
+}
+
+mjx-mtd {
+  display: table-cell;
+  text-align: center;
+  padding: .215em .4em;
+}
+
+mjx-mtd:first-child {
+  padding-left: 0;
+}
+
+mjx-mtd:last-child {
+  padding-right: 0;
+}
+
+mjx-mtable > * > mjx-itable > *:first-child > mjx-mtd {
+  padding-top: 0;
+}
+
+mjx-mtable > * > mjx-itable > *:last-child > mjx-mtd {
+  padding-bottom: 0;
+}
+
+mjx-tstrut {
+  display: inline-block;
+  height: 1em;
+  vertical-align: -.25em;
+}
+
+mjx-labels[align="left"] > mjx-mtr > mjx-mtd {
+  text-align: left;
+}
+
+mjx-labels[align="right"] > mjx-mtr > mjx-mtd {
+  text-align: right;
+}
+
+mjx-mtr mjx-mtd[rowalign="top"], mjx-mlabeledtr mjx-mtd[rowalign="top"] {
+  vertical-align: top;
+}
+
+mjx-mtr mjx-mtd[rowalign="center"], mjx-mlabeledtr mjx-mtd[rowalign="center"] {
+  vertical-align: middle;
+}
+
+mjx-mtr mjx-mtd[rowalign="bottom"], mjx-mlabeledtr mjx-mtd[rowalign="bottom"] {
+  vertical-align: bottom;
+}
+
+mjx-mtr mjx-mtd[rowalign="baseline"], mjx-mlabeledtr mjx-mtd[rowalign="baseline"] {
+  vertical-align: baseline;
+}
+
+mjx-mtr mjx-mtd[rowalign="axis"], mjx-mlabeledtr mjx-mtd[rowalign="axis"] {
+  vertical-align: .25em;
+}
+
+mjx-c {
+  display: inline-block;
+}
+
+mjx-utext {
+  display: inline-block;
+  padding: .75em 0 .2em 0;
+}
+
+mjx-c::before {
+  display: block;
+  width: 0;
+}
+
+.MJX-TEX {
+  font-family: MJXZERO, MJXTEX;
+}
+
+.TEX-B {
+  font-family: MJXZERO, MJXTEX-B;
+}
+
+.TEX-I {
+  font-family: MJXZERO, MJXTEX-I;
+}
+
+.TEX-MI {
+  font-family: MJXZERO, MJXTEX-MI;
+}
+
+.TEX-BI {
+  font-family: MJXZERO, MJXTEX-BI;
+}
+
+.TEX-S1 {
+  font-family: MJXZERO, MJXTEX-S1;
+}
+
+.TEX-S2 {
+  font-family: MJXZERO, MJXTEX-S2;
+}
+
+.TEX-S3 {
+  font-family: MJXZERO, MJXTEX-S3;
+}
+
+.TEX-S4 {
+  font-family: MJXZERO, MJXTEX-S4;
+}
+
+.TEX-A {
+  font-family: MJXZERO, MJXTEX-A;
+}
+
+.TEX-C {
+  font-family: MJXZERO, MJXTEX-C;
+}
+
+.TEX-CB {
+  font-family: MJXZERO, MJXTEX-CB;
+}
+
+.TEX-FR {
+  font-family: MJXZERO, MJXTEX-FR;
+}
+
+.TEX-FRB {
+  font-family: MJXZERO, MJXTEX-FRB;
+}
+
+.TEX-SS {
+  font-family: MJXZERO, MJXTEX-SS;
+}
+
+.TEX-SSB {
+  font-family: MJXZERO, MJXTEX-SSB;
+}
+
+.TEX-SSI {
+  font-family: MJXZERO, MJXTEX-SSI;
+}
+
+.TEX-SC {
+  font-family: MJXZERO, MJXTEX-SC;
+}
+
+.TEX-T {
+  font-family: MJXZERO, MJXTEX-T;
+}
+
+.TEX-V {
+  font-family: MJXZERO, MJXTEX-V;
+}
+
+.TEX-VB {
+  font-family: MJXZERO, MJXTEX-VB;
+}
+
+mjx-stretchy-v mjx-c, mjx-stretchy-h mjx-c {
+  font-family: MJXZERO, MJXTEX-S1, MJXTEX-S4, MJXTEX, MJXTEX-A ! important;
+}
+
+@font-face /* 0 */ {
+  font-family: MJXZERO;
+  src: url("place/to/fonts/MathJax_Zero.woff") format("woff");
+}
+
+@font-face /* 1 */ {
+  font-family: MJXTEX;
+  src: url("place/to/fonts/MathJax_Main-Regular.woff") format("woff");
+}
+
+@font-face /* 2 */ {
+  font-family: MJXTEX-B;
+  src: url("place/to/fonts/MathJax_Main-Bold.woff") format("woff");
+}
+
+@font-face /* 3 */ {
+  font-family: MJXTEX-I;
+  src: url("place/to/fonts/MathJax_Math-Italic.woff") format("woff");
+}
+
+@font-face /* 4 */ {
+  font-family: MJXTEX-MI;
+  src: url("place/to/fonts/MathJax_Main-Italic.woff") format("woff");
+}
+
+@font-face /* 5 */ {
+  font-family: MJXTEX-BI;
+  src: url("place/to/fonts/MathJax_Math-BoldItalic.woff") format("woff");
+}
+
+@font-face /* 6 */ {
+  font-family: MJXTEX-S1;
+  src: url("place/to/fonts/MathJax_Size1-Regular.woff") format("woff");
+}
+
+@font-face /* 7 */ {
+  font-family: MJXTEX-S2;
+  src: url("place/to/fonts/MathJax_Size2-Regular.woff") format("woff");
+}
+
+@font-face /* 8 */ {
+  font-family: MJXTEX-S3;
+  src: url("place/to/fonts/MathJax_Size3-Regular.woff") format("woff");
+}
+
+@font-face /* 9 */ {
+  font-family: MJXTEX-S4;
+  src: url("place/to/fonts/MathJax_Size4-Regular.woff") format("woff");
+}
+
+@font-face /* 10 */ {
+  font-family: MJXTEX-A;
+  src: url("place/to/fonts/MathJax_AMS-Regular.woff") format("woff");
+}
+
+@font-face /* 11 */ {
+  font-family: MJXTEX-C;
+  src: url("place/to/fonts/MathJax_Calligraphic-Regular.woff") format("woff");
+}
+
+@font-face /* 12 */ {
+  font-family: MJXTEX-CB;
+  src: url("place/to/fonts/MathJax_Calligraphic-Bold.woff") format("woff");
+}
+
+@font-face /* 13 */ {
+  font-family: MJXTEX-FR;
+  src: url("place/to/fonts/MathJax_Fraktur-Regular.woff") format("woff");
+}
+
+@font-face /* 14 */ {
+  font-family: MJXTEX-FRB;
+  src: url("place/to/fonts/MathJax_Fraktur-Bold.woff") format("woff");
+}
+
+@font-face /* 15 */ {
+  font-family: MJXTEX-SS;
+  src: url("place/to/fonts/MathJax_SansSerif-Regular.woff") format("woff");
+}
+
+@font-face /* 16 */ {
+  font-family: MJXTEX-SSB;
+  src: url("place/to/fonts/MathJax_SansSerif-Bold.woff") format("woff");
+}
+
+@font-face /* 17 */ {
+  font-family: MJXTEX-SSI;
+  src: url("place/to/fonts/MathJax_SansSerif-Italic.woff") format("woff");
+}
+
+@font-face /* 18 */ {
+  font-family: MJXTEX-SC;
+  src: url("place/to/fonts/MathJax_Script-Regular.woff") format("woff");
+}
+
+@font-face /* 19 */ {
+  font-family: MJXTEX-T;
+  src: url("place/to/fonts/MathJax_Typewriter-Regular.woff") format("woff");
+}
+
+@font-face /* 20 */ {
+  font-family: MJXTEX-V;
+  src: url("place/to/fonts/MathJax_Vector-Regular.woff") format("woff");
+}
+
+@font-face /* 21 */ {
+  font-family: MJXTEX-VB;
+  src: url("place/to/fonts/MathJax_Vector-Bold.woff") format("woff");
+}
+
+mjx-c.mjx-c28::before {
+  padding: 0.75em 0.389em 0.25em 0;
+  content: "(";
+}
+
+mjx-c.mjx-c29::before {
+  padding: 0.75em 0.389em 0.25em 0;
+  content: ")";
+}
+
+mjx-c.mjx-c31::before {
+  padding: 0.666em 0.5em 0 0;
+  content: "1";
+}
+
+mjx-c.mjx-c32::before {
+  padding: 0.666em 0.5em 0 0;
+  content: "2";
+}
+
+mjx-c.mjx-c3D::before {
+  padding: 0.583em 0.778em 0.082em 0;
+  content: "=";
+}
+
+mjx-c.mjx-c1D438.TEX-I::before {
+  padding: 0.68em 0.764em 0 0;
+  content: "E";
+}
+
+[noIC] mjx-c.mjx-c1D438.TEX-I:last-child::before {
+  padding-right: 0.738em;
+}
+
+mjx-c.mjx-c1D450.TEX-I::before {
+  padding: 0.442em 0.433em 0.011em 0;
+  content: "c";
+}
+
+mjx-c.mjx-c1D45A.TEX-I::before {
+  padding: 0.442em 0.878em 0.011em 0;
+  content: "m";
+}
+
+mjx-c.mjx-c1D6FC.TEX-I::before {
+  padding: 0.442em 0.64em 0.011em 0;
+  content: "\3B1";
+}
+
+mjx-c.mjx-c1D6FE.TEX-I::before {
+  padding: 0.441em 0.543em 0.216em 0;
+  content: "\3B3";
+}
+
+[noIC] mjx-c.mjx-c1D6FE.TEX-I:last-child::before {
+  padding-right: 0.518em;
+}
+</style>

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1-svg.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1-svg.html
@@ -1,0 +1,118 @@
+<p>Block math:</p>
+<div class="math-display"><mjx-container class="MathJax" jax="SVG" display="true" width="full" style="min-width: 18.027ex;"><svg style="vertical-align: -0.717ex; min-width: 18.027ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D438" d="M492 213Q472 213 472 226Q472 230 477 250T482 285Q482 316 461 323T364 330H312Q311 328 277 192T243 52Q243 48 254 48T334 46Q428 46 458 48T518 61Q567 77 599 117T670 248Q680 270 683 272Q690 274 698 274Q718 274 718 261Q613 7 608 2Q605 0 322 0H133Q31 0 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q146 66 215 342T285 622Q285 629 281 629Q273 632 228 634H197Q191 640 191 642T193 659Q197 676 203 680H757Q764 676 764 669Q764 664 751 557T737 447Q735 440 717 440H705Q698 445 698 453L701 476Q704 500 704 528Q704 558 697 578T678 609T643 625T596 632T532 634H485Q397 633 392 631Q388 629 386 622Q385 619 355 499T324 377Q347 376 372 376H398Q464 376 489 391T534 472Q538 488 540 490T557 493Q562 493 565 493T570 492T572 491T574 487T577 483L544 351Q511 218 508 216Q505 213 492 213Z"></path><path id="MJX-1-TEX-N-3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path><path id="MJX-1-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"></path><path id="MJX-1-TEX-I-1D450" d="M34 159Q34 268 120 355T306 442Q362 442 394 418T427 355Q427 326 408 306T360 285Q341 285 330 295T319 325T330 359T352 380T366 386H367Q367 388 361 392T340 400T306 404Q276 404 249 390Q228 381 206 359Q162 315 142 235T121 119Q121 73 147 50Q169 26 205 26H209Q321 26 394 111Q403 121 406 121Q410 121 419 112T429 98T420 83T391 55T346 25T282 0T202 -11Q127 -11 81 37T34 159Z"></path><path id="MJX-1-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path><path id="MJX-1-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-1-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-1-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0) scale(0.0181) translate(0, -817)"><g data-mml-node="math"><g data-mml-node="mtable" transform="translate(2078, 0) translate(-2078, 0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="1906.1 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0, -67)"><g data-mml-node="mtd"><g data-mml-node="mi"><use xlink:href="#MJX-1-TEX-I-1D438"></use></g><g data-mml-node="mo" transform="translate(1041.8, 0)"><use xlink:href="#MJX-1-TEX-N-3D"></use></g><g data-mml-node="mi" transform="translate(2097.6, 0)"><use xlink:href="#MJX-1-TEX-I-1D45A"></use></g><g data-mml-node="msup" transform="translate(2975.6, 0)"><g data-mml-node="mi"><use xlink:href="#MJX-1-TEX-I-1D450"></use></g><g data-mml-node="mn" transform="translate(433, 413) scale(0.707)"><use xlink:href="#MJX-1-TEX-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn-mass-energy_relation" transform="translate(0, -67)"><g data-mml-node="mtext"><use xlink:href="#MJX-1-TEX-N-28"></use><use xlink:href="#MJX-1-TEX-N-31" transform="translate(389, 0)"></use><use xlink:href="#MJX-1-TEX-N-29" transform="translate(889, 0)"></use></g></g></g></svg></g></g></g></g></svg></mjx-container></div>
+<p>See equation <span class="math-inline"><mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 1278 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-2-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><a href="#mjx-eqn-mass-energy_relation"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="1000" y="-250"></rect><g data-mml-node="mrow" class="MathJax_ref"><g data-mml-node="mtext"><use xlink:href="#MJX-2-TEX-N-28"></use><use xlink:href="#MJX-2-TEX-N-31" transform="translate(389, 0)"></use><use xlink:href="#MJX-2-TEX-N-29" transform="translate(889, 0)"></use></g></g></a></g></g></svg></mjx-container></span>.</p>
+<style>
+mjx-container[jax="SVG"] {
+  direction: ltr;
+}
+
+mjx-container[jax="SVG"] > svg {
+  overflow: visible;
+}
+
+mjx-container[jax="SVG"] > svg a {
+  fill: blue;
+  stroke: blue;
+}
+
+mjx-container[jax="SVG"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+mjx-container[jax="SVG"][display="true"][width="full"] {
+  display: flex;
+}
+
+mjx-container[jax="SVG"][justify="left"] {
+  text-align: left;
+}
+
+mjx-container[jax="SVG"][justify="right"] {
+  text-align: right;
+}
+
+g[data-mml-node="merror"] > g {
+  fill: red;
+  stroke: red;
+}
+
+g[data-mml-node="merror"] > rect[data-background] {
+  fill: yellow;
+  stroke: none;
+}
+
+g[data-mml-node="mtable"] > line[data-line] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > rect[data-frame] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > .mjx-dashed {
+  stroke-dasharray: 140;
+}
+
+g[data-mml-node="mtable"] > .mjx-dotted {
+  stroke-linecap: round;
+  stroke-dasharray: 0,140;
+}
+
+g[data-mml-node="mtable"] > g > svg {
+  overflow: visible;
+}
+
+[jax="SVG"] mjx-tool {
+  display: inline-block;
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+[jax="SVG"] mjx-tool > mjx-tip {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+mjx-tool > mjx-tip {
+  display: inline-block;
+  padding: .2em;
+  border: 1px solid #888;
+  font-size: 70%;
+  background-color: #F8F8F8;
+  color: black;
+  box-shadow: 2px 2px 5px #AAAAAA;
+}
+
+g[data-mml-node="maction"][data-toggle] {
+  cursor: pointer;
+}
+
+mjx-status {
+  display: block;
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+  min-width: 25%;
+  padding: .2em .4em;
+  border: 1px solid #888;
+  font-size: 90%;
+  background-color: #F8F8F8;
+  color: black;
+}
+
+foreignObject[data-mjx-xml] {
+  font-family: initial;
+  line-height: normal;
+  overflow: visible;
+}
+
+.MathJax path {
+  stroke-width: 3;
+}
+</style>

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1.html
@@ -1,0 +1,3 @@
+<p>Block math:</p>
+<div class="math-display">\begin{equation}\label{mass-energy relation}E = m c^2\end{equation}</div>
+<p>See equation <span class="math-inline">\eqref{mass-energy relation}</span>.</p>

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-2-svg.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-2-svg.html
@@ -1,0 +1,119 @@
+<p>Block math:</p>
+<div class="math-display"><mjx-container class="MathJax" jax="SVG" display="true" width="full" style="min-width: 21.072ex;"><svg style="vertical-align: -0.717ex; min-width: 21.072ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"></path><path id="MJX-1-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path><path id="MJX-1-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"></path><path id="MJX-1-TEX-I-1D44F" d="M73 647Q73 657 77 670T89 683Q90 683 161 688T234 694Q246 694 246 685T212 542Q204 508 195 472T180 418L176 399Q176 396 182 402Q231 442 283 442Q345 442 383 396T422 280Q422 169 343 79T173 -11Q123 -11 82 27T40 150V159Q40 180 48 217T97 414Q147 611 147 623T109 637Q104 637 101 637H96Q86 637 83 637T76 640T73 647ZM336 325V331Q336 405 275 405Q258 405 240 397T207 376T181 352T163 330L157 322L136 236Q114 150 114 114Q114 66 138 42Q154 26 178 26Q211 26 245 58Q270 81 285 114T318 219Q336 291 336 325Z"></path><path id="MJX-1-TEX-N-3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path><path id="MJX-1-TEX-I-1D450" d="M34 159Q34 268 120 355T306 442Q362 442 394 418T427 355Q427 326 408 306T360 285Q341 285 330 295T319 325T330 359T352 380T366 386H367Q367 388 361 392T340 400T306 404Q276 404 249 390Q228 381 206 359Q162 315 142 235T121 119Q121 73 147 50Q169 26 205 26H209Q321 26 394 111Q403 121 406 121Q410 121 419 112T429 98T420 83T391 55T346 25T282 0T202 -11Q127 -11 81 37T34 159Z"></path><path id="MJX-1-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-1-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-1-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0) scale(0.0181) translate(0, -817)"><g data-mml-node="math"><g data-mml-node="mtable" transform="translate(2078, 0) translate(-2078, 0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="2578.8 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0, -67)"><g data-mml-node="mtd"><g data-mml-node="msup"><g data-mml-node="mi"><use xlink:href="#MJX-1-TEX-I-1D44E"></use></g><g data-mml-node="mn" transform="translate(529, 413) scale(0.707)"><use xlink:href="#MJX-1-TEX-N-32"></use></g></g><g data-mml-node="mo" transform="translate(1154.8, 0)"><use xlink:href="#MJX-1-TEX-N-2B"></use></g><g data-mml-node="msup" transform="translate(2155, 0)"><g data-mml-node="mi"><use xlink:href="#MJX-1-TEX-I-1D44F"></use></g><g data-mml-node="mn" transform="translate(429, 413) scale(0.707)"><use xlink:href="#MJX-1-TEX-N-32"></use></g></g><g data-mml-node="mo" transform="translate(3265.3, 0)"><use xlink:href="#MJX-1-TEX-N-3D"></use></g><g data-mml-node="msup" transform="translate(4321.1, 0)"><g data-mml-node="mi"><use xlink:href="#MJX-1-TEX-I-1D450"></use></g><g data-mml-node="mn" transform="translate(433, 413) scale(0.707)"><use xlink:href="#MJX-1-TEX-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn-pythagorean_theorem" transform="translate(0, -67)"><g data-mml-node="mtext"><use xlink:href="#MJX-1-TEX-N-28"></use><use xlink:href="#MJX-1-TEX-N-31" transform="translate(389, 0)"></use><use xlink:href="#MJX-1-TEX-N-29" transform="translate(889, 0)"></use></g></g></g></svg></g></g></g></g></svg></mjx-container></div>
+<p>See equation <span class="math-inline"><mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 1278 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-2-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><a href="#mjx-eqn-pythagorean_theorem"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="1000" y="-250"></rect><g data-mml-node="mrow" class="MathJax_ref"><g data-mml-node="mtext"><use xlink:href="#MJX-2-TEX-N-28"></use><use xlink:href="#MJX-2-TEX-N-31" transform="translate(389, 0)"></use><use xlink:href="#MJX-2-TEX-N-29" transform="translate(889, 0)"></use></g></g></a></g></g></svg></mjx-container></span>.</p>
+<p>Reference to an undefined equation <span class="math-inline"><mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="4.964ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 2194 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-3-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-3-TEX-N-3F" d="M226 668Q190 668 162 656T124 632L114 621Q116 621 119 620T130 616T145 607T157 591T162 567Q162 544 147 529T109 514T71 528T55 566Q55 625 100 661T199 704Q201 704 210 704T224 705H228Q281 705 320 692T378 656T407 612T416 567Q416 503 361 462Q267 395 247 303Q242 279 242 241V224Q242 205 239 202T222 198T205 201T202 218V249Q204 320 220 371T255 445T292 491T315 537Q317 546 317 574V587Q317 604 315 615T304 640T277 661T226 668ZM162 61Q162 89 180 105T224 121Q247 119 264 104T281 61Q281 31 264 16T222 1Q197 1 180 16T162 61Z"></path><path id="MJX-3-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="math"><a href="#"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="2194" height="1000" y="-250"></rect><g data-mml-node="mrow" class="MathJax_ref"><g data-mml-node="mtext"><use xlink:href="#MJX-3-TEX-N-28"></use><use xlink:href="#MJX-3-TEX-N-3F" transform="translate(389, 0)"></use><use xlink:href="#MJX-3-TEX-N-3F" transform="translate(861, 0)"></use><use xlink:href="#MJX-3-TEX-N-3F" transform="translate(1333, 0)"></use><use xlink:href="#MJX-3-TEX-N-29" transform="translate(1805, 0)"></use></g></g></a></g></g></svg></mjx-container></span>.</p>
+<style>
+mjx-container[jax="SVG"] {
+  direction: ltr;
+}
+
+mjx-container[jax="SVG"] > svg {
+  overflow: visible;
+}
+
+mjx-container[jax="SVG"] > svg a {
+  fill: blue;
+  stroke: blue;
+}
+
+mjx-container[jax="SVG"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+mjx-container[jax="SVG"][display="true"][width="full"] {
+  display: flex;
+}
+
+mjx-container[jax="SVG"][justify="left"] {
+  text-align: left;
+}
+
+mjx-container[jax="SVG"][justify="right"] {
+  text-align: right;
+}
+
+g[data-mml-node="merror"] > g {
+  fill: red;
+  stroke: red;
+}
+
+g[data-mml-node="merror"] > rect[data-background] {
+  fill: yellow;
+  stroke: none;
+}
+
+g[data-mml-node="mtable"] > line[data-line] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > rect[data-frame] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > .mjx-dashed {
+  stroke-dasharray: 140;
+}
+
+g[data-mml-node="mtable"] > .mjx-dotted {
+  stroke-linecap: round;
+  stroke-dasharray: 0,140;
+}
+
+g[data-mml-node="mtable"] > g > svg {
+  overflow: visible;
+}
+
+[jax="SVG"] mjx-tool {
+  display: inline-block;
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+[jax="SVG"] mjx-tool > mjx-tip {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+mjx-tool > mjx-tip {
+  display: inline-block;
+  padding: .2em;
+  border: 1px solid #888;
+  font-size: 70%;
+  background-color: #F8F8F8;
+  color: black;
+  box-shadow: 2px 2px 5px #AAAAAA;
+}
+
+g[data-mml-node="maction"][data-toggle] {
+  cursor: pointer;
+}
+
+mjx-status {
+  display: block;
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+  min-width: 25%;
+  padding: .2em .4em;
+  border: 1px solid #888;
+  font-size: 90%;
+  background-color: #F8F8F8;
+  color: black;
+}
+
+foreignObject[data-mjx-xml] {
+  font-family: initial;
+  line-height: normal;
+  overflow: visible;
+}
+
+.MathJax path {
+  stroke-width: 3;
+}
+</style>

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-2.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-2.html
@@ -1,0 +1,4 @@
+<p>Block math:</p>
+<div class="math-display">\begin{equation}\label{pythagorean theorem}a^2 + b^2 = c^2\end{equation}</div>
+<p>See equation <span class="math-inline">\eqref{pythagorean theorem}</span>.</p>
+<p>Reference to an undefined equation <span class="math-inline">\eqref{mass-energy relation}</span>.</p>

--- a/packages/rehype-mathjax/test/index.js
+++ b/packages/rehype-mathjax/test/index.js
@@ -153,6 +153,27 @@ test('rehype-mathjax', function (t) {
   t.equal(
     unified()
       .use(parseHtml, {fragment: true})
+      .use(svg, {tex: {tags: 'ams'}})
+      .use(stringify)
+      .processSync(
+        vfile.readSync({
+          dirname: fixtures,
+          basename: 'equation-numbering-2.html'
+        })
+      )
+      .toString(),
+    String(
+      vfile.readSync({
+        dirname: fixtures,
+        basename: 'equation-numbering-2-svg.html'
+      })
+    ).trim(),
+    'should render SVG with reference to an undefined equation'
+  )
+
+  t.equal(
+    unified()
+      .use(parseHtml, {fragment: true})
       .use(chtml, {fontURL: 'place/to/fonts', tex: {tags: 'ams'}})
       .use(stringify)
       .processSync(
@@ -169,6 +190,42 @@ test('rehype-mathjax', function (t) {
       })
     ).trim(),
     'should render CHTML with equation numbers'
+  )
+
+  t.equal(
+    (() => {
+      const processor = unified()
+        .use(parseHtml, {fragment: true})
+        .use(svg, {tex: {tags: 'ams'}})
+        .use(stringify)
+      return ['equation-numbering-1.html', 'equation-numbering-2.html']
+        .map((basename) =>
+          processor
+            .processSync(
+              vfile.readSync({
+                dirname: fixtures,
+                basename: basename
+              })
+            )
+            .toString()
+        )
+        .join('')
+    })(),
+    [
+      String(
+        vfile.readSync({
+          dirname: fixtures,
+          basename: 'equation-numbering-1-svg.html'
+        })
+      ).trim(),
+      String(
+        vfile.readSync({
+          dirname: fixtures,
+          basename: 'equation-numbering-2-svg.html'
+        })
+      ).trim()
+    ].join(''),
+    'should render SVG with equation numbers'
   )
 
   t.end()

--- a/packages/rehype-mathjax/test/index.js
+++ b/packages/rehype-mathjax/test/index.js
@@ -129,5 +129,47 @@ test('rehype-mathjax', function (t) {
     'should support custom `inlineMath` and `displayMath` delimiters for browser'
   )
 
+  t.equal(
+    unified()
+      .use(parseHtml, {fragment: true})
+      .use(svg, {tex: {tags: 'ams'}})
+      .use(stringify)
+      .processSync(
+        vfile.readSync({
+          dirname: fixtures,
+          basename: 'equation-numbering-1.html'
+        })
+      )
+      .toString(),
+    String(
+      vfile.readSync({
+        dirname: fixtures,
+        basename: 'equation-numbering-1-svg.html'
+      })
+    ).trim(),
+    'should render SVG with equation numbers'
+  )
+
+  t.equal(
+    unified()
+      .use(parseHtml, {fragment: true})
+      .use(chtml, {fontURL: 'place/to/fonts', tex: {tags: 'ams'}})
+      .use(stringify)
+      .processSync(
+        vfile.readSync({
+          dirname: fixtures,
+          basename: 'equation-numbering-1.html'
+        })
+      )
+      .toString(),
+    String(
+      vfile.readSync({
+        dirname: fixtures,
+        basename: 'equation-numbering-1-chtml.html'
+      })
+    ).trim(),
+    'should render CHTML with equation numbers'
+  )
+
   t.end()
 })


### PR DESCRIPTION
Closes GH-53

I extend the options type of the non-browser `rehype-mathjax` plugin to enable configuring the TeX input processor in a non-breaking way.
I kept the modifications to a minimum, but restructuring of the plugin may be required in the future.
Extending the options this way has a number of consequences:

* The type for the options now has format `OutputOptions & {tex: TexInputOptions}` which is different from that of MathJax. A breaking change will be required in the future to make the options type one of `{tex: TexInputOptions, svg: SvgOutputOptions }` or `{tex: TexInputOptions, chtml: ChtmlOutputOptions}`.
* Since MathJax throws when unsupported options keys are supplied to the various processors, a hack is introduced to remove the added `tex` key from the output options.
* When automatic equation numbering is used, the transformer would throw when processing multiple documents using the same `rehype` instance. That is because instances of the MathJax document may not be reused across processed documents in this case. Creation of the renderer is moved from the attacher to the transformer.
* Validation to ensure that a `fontURL` is provided in the CHTML output processor would take place in the attacher from the `createRenderer` function. Because that creation was moved to the transformer, a hack is introduced as an optional parameter to the `createPlugin` function to perform the validation in the attacher without adding imports.
* The `createRenderer` function would create a JSDOM adaptor and register a HTML handler in MathJax. This would take place in the attacher (through the `createRenderer` function), which is appropriate since `rehype-mathjax` does not allow configuring the handler (to add the `AssistiveMmlHandler` as in [this demo](https://github.com/mathjax/MathJax-demos-node/tree/master/direct) for instance). The adaptor creation and handler registration have been moved outside the `renderer` function to prevent a new handler to be registered for each processed document. This handler is never unregistered. In the future, registering of the handlers should be moved to the beginning of the transformer, and the handlers should be unregistered at the end of the transformer.