### PR TITLE
Fix typo in readme of `rehype-katex`

### DIFF
--- a/packages/rehype-katex/readme.md
+++ b/packages/rehype-katex/readme.md
@@ -196,7 +196,7 @@ schema, and run `rehype-katex` afterwards.
 Like so:
 
 ```js
-import rehypeSanitize, {defaultSchema} from 'rehype-stringify'
+import rehypeSanitize, {defaultSchema} from 'rehype-sanitize'
 
 const mathSanitizeSchema = {
   ...defaultSchema,


### PR DESCRIPTION


<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`rehype-katex` readme - Security
```diff
- import rehypeSanitize, {defaultSchema} from 'rehype-stringify'
+ import rehypeSanitize, {defaultSchema} from 'rehype-sanitize'
```

<!--do not edit: pr-->
