### PR TITLE
Refactor Wording, few details on syntax in readme

### DIFF
--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -151,7 +151,8 @@ See its readme for parse details:
 > That means escapes don’t work inside math but you can use more dollars around
 > the math instead: `$$\raisebox{0.25em}{$\frac a b$}$$`
 
-> 👉 **Note**: Like code, the difference between “inline” and “block”, is in the line endings:
+> 👉 **Note**: Like code, the difference between “inline” and “block”,
+> is in the line endings:
 > 
 > ```markdown
 > $$inline$$

--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -140,8 +140,8 @@ If you turn this off, you can still use two or more dollars for text math.
 
 This plugin applies a micromark extensions to parse the syntax.
 The syntax basically follows how code works in markdown, except that dollars (`$`)
-are used instead of backticks (`` ` ``), and you must have a newline in the text math
-in order to have it be considered a math block. 
+are used instead of backticks (`` ` ``), and you must have a newline
+in the text math in order to have it be considered a math block. 
 See its readme for parse details:
 
 *   [`micromark-extension-math`](https://github.com/micromark/micromark-extension-math#syntax)

--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -140,8 +140,19 @@ If you turn this off, you can still use two or more dollars for text math.
 
 This plugin applies a micromark extensions to parse the syntax.
 The syntax basically follows how code works in markdown, except that dollars (`$`)
-are used instead of backticks (`` ` ``), and you must have a newline
-in the text math in order to have it be considered a math block. 
+are used instead of backticks (`` ` ``) and that 2 or more dollars instead of 3
+or more backticks is enough for blocks.
+Like code, the difference between “inline” and “block”, is in the line endings:
+
+```
+$$inline$$
+
+$$
+block
+$$
+```
+
+
 See its readme for parse details:
 
 *   [`micromark-extension-math`](https://github.com/micromark/micromark-extension-math#syntax)

--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -140,7 +140,8 @@ If you turn this off, you can still use two or more dollars for text math.
 
 This plugin applies a micromark extensions to parse the syntax.
 The syntax basically follows how code works in markdown, except that dollars (`$`)
-are used instead of backticks (`` ` ``), and you must have a newline in the text math in order to have it be considered a math block. 
+are used instead of backticks (`` ` ``), and you must have a newline in the text math
+in order to have it be considered a math block. 
 See its readme for parse details:
 
 *   [`micromark-extension-math`](https://github.com/micromark/micromark-extension-math#syntax)

--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -139,9 +139,8 @@ If you turn this off, you can still use two or more dollars for text math.
 ## Syntax
 
 This plugin applies a micromark extensions to parse the syntax.
-That basically follows how code works in markdown, except that dollars (`$`)
-are used instead of backticks (`` ` ``), and that two dollars instead of 3 is
-enough for blocks.
+The syntax basically follows how code works in markdown, except that dollars (`$`)
+are used instead of backticks (`` ` ``), and you must have a newline in the text math in order to have it be considered a math block. 
 See its readme for parse details:
 
 *   [`micromark-extension-math`](https://github.com/micromark/micromark-extension-math#syntax)

--- a/packages/remark-math/readme.md
+++ b/packages/remark-math/readme.md
@@ -142,16 +142,6 @@ This plugin applies a micromark extensions to parse the syntax.
 The syntax basically follows how code works in markdown, except that dollars (`$`)
 are used instead of backticks (`` ` ``) and that 2 or more dollars instead of 3
 or more backticks is enough for blocks.
-Like code, the difference between “inline” and “block”, is in the line endings:
-
-```
-$$inline$$
-
-$$
-block
-$$
-```
-
 
 See its readme for parse details:
 
@@ -160,6 +150,16 @@ See its readme for parse details:
 > 👉 **Note**: `$math$` works similar to `` `code` ``.
 > That means escapes don’t work inside math but you can use more dollars around
 > the math instead: `$$\raisebox{0.25em}{$\frac a b$}$$`
+
+> 👉 **Note**: Like code, the difference between “inline” and “block”, is in the line endings:
+> 
+> ```markdown
+> $$inline$$
+> 
+> $$
+> block
+> $$
+> ```
 
 ## HTML
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Updated some minor wording changes and clarified that a math block needs a newline character in it or else it will not be a math block.

Here is the example of it not being a math block if it is only 1 line but multiple dollar signs: https://astexplorer.net/#/gist/111c4f5728f9c80696a9422a7c9c99f0/aa4f9e212560494d7ebb5d826e6777137afa59d1

Here are the contents of the AST example just in case it is not the same as what I intended for the above link:
``` markdown
$$$L = \frac{1}{2} \rho v^2 S C_L$$$

$$
Math block
$$
```

<!--do not edit: pr-->