### PR TITLE
Refactor unclear wording re vulnerabilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,10 +143,9 @@ mjx-container[jax="SVG"] {
 ## Security
 
 Assuming you trust KaTeX/MathJax, using `rehype-katex`/`rehype-mathjax` is
-safe.
-A vulnerability in them could open you to a
-[cross-site scripting (XSS)][wiki-xss] attack.
-See their readmes for more info.
+safe. If a vulnerability were to be introduced in them, it could open you up to
+a [cross-site scripting (XSS)][wiki-xss] attack. See their readmes for more
+info.
 
 ## Contribute
 

--- a/readme.md
+++ b/readme.md
@@ -143,9 +143,10 @@ mjx-container[jax="SVG"] {
 ## Security
 
 Assuming you trust KaTeX/MathJax, using `rehype-katex`/`rehype-mathjax` is
-safe. If a vulnerability were to be introduced in them, it could open you up to
-a [cross-site scripting (XSS)][wiki-xss] attack. See their readmes for more
-info.
+safe.
+If a vulnerability is introduced in them, it opens you up to a
+[cross-site scripting (XSS)][wiki-xss] attack.
+See their readmes for more info.
 
 ## Contribute
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I found the wording to be confusing regarding vulnerabilities in `rehype-katex` and `rehype-mathjax`. The current wording:

> A vulnerability in them could open you to a cross-site scripting (XSS) attack. See their readmes for more info.

This wording makes it seem like there already exists a vulnerability in them and to visit the readme to learn more about said vulnerability. I believe the intended meaning is to warn about potential future vulnerabilities. My proposed wording change is:

> If a vulnerability were to be introduced in them, it could open you up to a cross-site scripting (XSS) attack. See their readmes for more info.

<!--do not edit: pr-->
