### PR TITLE
fixed an issue that nextjs cannot render katex's mhchem extension

### DIFF
--- a/packages/rehype-katex/lib/index.js
+++ b/packages/rehype-katex/lib/index.js
@@ -16,7 +16,7 @@ import {toText} from 'hast-util-to-text'
 import katex from 'katex'
 import {SKIP, visitParents} from 'unist-util-visit-parents'
 // eslint-disable-next-line import/no-unassigned-import
-import 'katex/dist/contrib/mhchem'
+import 'katex/contrib/mhchem'
 
 /** @type {Readonly<Options>} */
 const emptyOptions = {}

--- a/packages/rehype-katex/lib/index.js
+++ b/packages/rehype-katex/lib/index.js
@@ -15,6 +15,8 @@ import {fromHtmlIsomorphic} from 'hast-util-from-html-isomorphic'
 import {toText} from 'hast-util-to-text'
 import katex from 'katex'
 import {SKIP, visitParents} from 'unist-util-visit-parents'
+// eslint-disable-next-line import/no-unassigned-import
+import 'katex/dist/contrib/mhchem'
 
 /** @type {Readonly<Options>} */
 const emptyOptions = {}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently, mhchem is not supported in remark-katex, explicitly import the mhchem extension to make it work. 
Reference:
https://github.com/KaTeX/KaTeX/blob/main/contrib/mhchem/README.md
https://github.com/marktext/marktext/issues/2301#issuecomment-890895284

<!--do not edit: pr-->
