### PR TITLE
in case properties is undefined

### DIFF
--- a/packages/rehype-katex/lib/index.js
+++ b/packages/rehype-katex/lib/index.js
@@ -42,7 +42,7 @@ export default function rehypeKatex(options) {
    */
   return function (tree, file) {
     visitParents(tree, 'element', function (element, parents) {
-      const classes = Array.isArray(element.properties.className)
+      const classes = Array.isArray(element.properties?.className)
         ? element.properties.className
         : emptyClasses
       // This class can be generated from markdown with ` ```math `.


### PR DESCRIPTION
properties field in Element type is optional (according to hast definition). when they are, this will crash. Maybe should be more tolerate here?

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes
use optional chaining when accessing properties of `Element`.

<!--do not edit: pr-->
