### PR TITLE
Imply the existence of third party rehype plugins for unsupported math rendrers in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ and to render math with KaTeX or MathJax.
 
 When dealing with markdown, you optionally use `remark-math`, or alternatively
 use fenced code (` ```math `).
-Then, you either use `rehype-katex` or `rehype-mathjax` to render math in HTML.
+Then, you either use `rehype-katex` or `rehype-mathjax` (or one of third party rehype plugins [(see here for major ones)](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) for other math renderers e.g. Temml) to render math in HTML.
 
 ## When should I use this?
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,11 @@ and to render math with KaTeX or MathJax.
 
 When dealing with markdown, you optionally use `remark-math`, or alternatively
 use fenced code (` ```math `).
-Then, you either use `rehype-katex` or `rehype-mathjax` (or one of third party rehype plugins [(see here for major ones)](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md#list-of-plugins) for other math renderers e.g. Temml) to render math in HTML.
+Then, you either use `rehype-katex` or `rehype-mathjax` to render math in HTML.
+
+There are also other plugins that work with `remark-math`.
+Such as [`rehype-mathml`](https://github.com/Daiji256/rehype-mathml)
+which uses [`ronkok/Temml`](https://github.com/ronkok/Temml).
 
 ## When should I use this?
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Related:

- #107
- https://github.com/rehypejs/rehype/pull/186
- https://github.com/rehypejs/rehype/pull/189

The current explanation may cause the reader to give up looking for third party plug-ins supporting math renderers other than MathJax or KaTeX.
There is [`@daiji256/rehype-mathml`](https://www.npmjs.com/package/@daiji256/rehype-mathml) for Temml, which has been introduced in [the plugin list in rehype](https://github.com/rehypejs/rehype/blob/main/doc/plugins.md), and we want to imply its existence (just implication because this README is mainly for official packages).

<!--do not edit: pr-->
