### PR TITLE
feat(rehype-mathjax)!: update mathjax from v3 to v4

### DIFF
--- a/packages/rehype-mathjax/lib/chtml.js
+++ b/packages/rehype-mathjax/lib/chtml.js
@@ -1,4 +1,19 @@
-import {CHTML as Chtml} from 'mathjax-full/js/output/chtml.js'
+// CHTML font metric data — side-effect imports register metrics on the font
+// class. Only math-essential files (~113 KB). See lib/svg.js for rationale.
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/accents.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/arrows.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/calligraphic.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/double-struck.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/fraktur.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/marrows.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/math.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/mshapes.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/script.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/shapes.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/symbols.js'
+import '@mathjax/mathjax-newcm-font/js/chtml/dynamic/variants.js'
+
+import {CHTML as Chtml} from '@mathjax/src/js/output/chtml.js'
 import {createPlugin} from './create-plugin.js'
 import {createRenderer} from './create-renderer.js'
 

--- a/packages/rehype-mathjax/lib/create-plugin.js
+++ b/packages/rehype-mathjax/lib/create-plugin.js
@@ -79,7 +79,7 @@
  *     // …
  *     .use(rehypeMathjaxChtml, {
  *       chtml: {
- *         fontURL: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/chtml/fonts/woff-v2'
+ *         fontURL: 'https://cdn.jsdelivr.net/npm/@mathjax/mathjax-newcm-font/chtml/woff2'
  *       }
  *     })
  *     // …

--- a/packages/rehype-mathjax/lib/create-renderer.js
+++ b/packages/rehype-mathjax/lib/create-renderer.js
@@ -1,20 +1,24 @@
 /**
  * @import {Element, Text} from 'hast'
- * @import {LiteDocument} from 'mathjax-full/js/adaptors/lite/Document.js'
- * @import {LiteElement} from 'mathjax-full/js/adaptors/lite/Element.js'
- * @import {LiteText} from 'mathjax-full/js/adaptors/lite/Text.js'
- * @import {MathDocument} from 'mathjax-full/js/core/MathDocument.js'
- * @import {OutputJax} from 'mathjax-full/js/core/OutputJax.js'
- * @import {HTMLHandler as HtmlHandler} from 'mathjax-full/js/handlers/html/HTMLHandler.js'
+ * @import {LiteDocument} from '@mathjax/src/js/adaptors/lite/Document.js'
+ * @import {LiteElement} from '@mathjax/src/js/adaptors/lite/Element.js'
+ * @import {LiteText} from '@mathjax/src/js/adaptors/lite/Text.js'
+ * @import {MathDocument} from '@mathjax/src/js/core/MathDocument.js'
+ * @import {OutputJax} from '@mathjax/src/js/core/OutputJax.js'
+ * @import {HTMLHandler as HtmlHandler} from '@mathjax/src/js/handlers/html/HTMLHandler.js'
  * @import {Options, Renderer} from './create-plugin.js'
  */
 
 import {h} from 'hastscript'
-import {liteAdaptor as liteAdapter} from 'mathjax-full/js/adaptors/liteAdaptor.js'
-import {RegisterHTMLHandler as registerHtmlHandler} from 'mathjax-full/js/handlers/html.js'
-import {AllPackages as allPackages} from 'mathjax-full/js/input/tex/AllPackages.js'
-import {TeX as Tex} from 'mathjax-full/js/input/tex.js'
-import {mathjax} from 'mathjax-full/js/mathjax.js'
+import {liteAdaptor as liteAdapter} from '@mathjax/src/js/adaptors/liteAdaptor.js'
+import {RegisterHTMLHandler as registerHtmlHandler} from '@mathjax/src/js/handlers/html.js'
+import {TeX as Tex} from '@mathjax/src/js/input/tex.js'
+import {mathjax} from '@mathjax/src/js/mathjax.js'
+import {allPackages} from './tex-packages.js'
+// No-op async loader: all font data is pre-loaded via static imports
+// in the entry points (svg.js, chtml.js). This prevents MathJax from
+// attempting dynamic loading at runtime.
+mathjax.asyncLoad = () => Promise.resolve()
 
 /**
  * Create a renderer.
@@ -38,6 +42,21 @@ export function createRenderer(options, output) {
       const adapter = liteAdapter()
       handler = registerHtmlHandler(adapter)
       document = mathjax.document('', {InputJax: input, OutputJax: output})
+      // Apply pre-loaded dynamic font data to this output instance.
+      // The font side-effect imports in svg.js / chtml.js registered
+      // setup() functions on the font class via dynamicSetup(). We must
+      // call them on each new font instance because loadDynamicFiles()
+      // has a class-level `if (!df.promise)` guard that skips setup for
+      // instances created after the first.
+      const font = /** @type {any} */ (output).font
+      if (font) {
+        const dynamicFiles = font.constructor.dynamicFiles
+        for (const name of Object.keys(dynamicFiles)) {
+          const df = dynamicFiles[name]
+          df.promise ??= Promise.resolve()
+          df.setup(font)
+        }
+      }
     },
     render(value, options) {
       // Cast as this practically results in an element instead of an `MmlNode`.

--- a/packages/rehype-mathjax/lib/svg.js
+++ b/packages/rehype-mathjax/lib/svg.js
@@ -1,4 +1,32 @@
-import {SVG as Svg} from 'mathjax-full/js/output/svg.js'
+// SVG font glyph data — side-effect imports register SVG path strings on the
+// font class for character ranges beyond the static base font.
+//
+// Only math-essential files are imported (~1.1 MB). Extended scripts (Cyrillic,
+// Arabic, Hebrew, Braille, Cherokee, Devanagari, etc.) and extra font variants
+// (sans-serif, monospace, phonetics, etc.) are omitted to keep the bundle close
+// to v3's ~1 MB. Users needing those ranges can add them via a custom plugin.
+//
+// Full list of available files (40 total, ~9.9 MB):
+//   PUA, accents, accents-b-i, arabic, arrows, braille, braille-d,
+//   calligraphic, cherokee, cyrillic, cyrillic-ss, devanagari, double-struck,
+//   fraktur, greek, greek-ss, hebrew, latin, latin-b, latin-bi, latin-i,
+//   marrows, math, monospace, monospace-ex, monospace-l, mshapes, phonetics,
+//   phonetics-ss, sans-serif, sans-serif-b, sans-serif-bi, sans-serif-ex,
+//   sans-serif-i, sans-serif-r, script, shapes, symbols, symbols-b-i, variants
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/accents.js'       //  72 KB — accented math characters
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/arrows.js'        // 229 KB — extended arrows
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/calligraphic.js'  //  40 KB — \mathcal
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/double-struck.js' //  42 KB — \mathbb (ℝ, ℂ, ℤ)
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/fraktur.js'       //  77 KB — \mathfrak
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/marrows.js'       //  43 KB — more arrow shapes
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/math.js'          // 199 KB — extra math symbols
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/mshapes.js'       //  45 KB — math shapes
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/script.js'        //  71 KB — \mathscr
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/shapes.js'        // 111 KB — shapes and delimiters
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/symbols.js'       // 178 KB — extra symbols
+import '@mathjax/mathjax-newcm-font/js/svg/dynamic/variants.js'      //  17 KB — TeX variant characters
+
+import {SVG as Svg} from '@mathjax/src/js/output/svg.js'
 import {createPlugin} from './create-plugin.js'
 import {createRenderer} from './create-renderer.js'
 

--- a/packages/rehype-mathjax/lib/tex-packages.js
+++ b/packages/rehype-mathjax/lib/tex-packages.js
@@ -1,0 +1,94 @@
+// TeX extension side-effect imports (registers each package with MathJax).
+// Includes all v4 packages except autoload (requires async asyncLoad) and
+// bboldx (requires font variant not in NCM).
+import '@mathjax/src/js/input/tex/action/ActionConfiguration.js'
+import '@mathjax/src/js/input/tex/ams/AmsConfiguration.js'
+import '@mathjax/src/js/input/tex/amscd/AmsCdConfiguration.js'
+import '@mathjax/src/js/input/tex/base/BaseConfiguration.js'
+import '@mathjax/src/js/input/tex/bbm/BbmConfiguration.js'
+// bboldx omitted — requires -bboldx font variant not in the NCM font package.
+import '@mathjax/src/js/input/tex/bbox/BboxConfiguration.js'
+import '@mathjax/src/js/input/tex/begingroup/BegingroupConfiguration.js'
+import '@mathjax/src/js/input/tex/boldsymbol/BoldsymbolConfiguration.js'
+import '@mathjax/src/js/input/tex/braket/BraketConfiguration.js'
+import '@mathjax/src/js/input/tex/bussproofs/BussproofsConfiguration.js'
+import '@mathjax/src/js/input/tex/cancel/CancelConfiguration.js'
+import '@mathjax/src/js/input/tex/cases/CasesConfiguration.js'
+import '@mathjax/src/js/input/tex/centernot/CenternotConfiguration.js'
+import '@mathjax/src/js/input/tex/color/ColorConfiguration.js'
+import '@mathjax/src/js/input/tex/colortbl/ColortblConfiguration.js'
+import '@mathjax/src/js/input/tex/colorv2/ColorV2Configuration.js'
+import '@mathjax/src/js/input/tex/configmacros/ConfigMacrosConfiguration.js'
+import '@mathjax/src/js/input/tex/dsfont/DsfontConfiguration.js'
+import '@mathjax/src/js/input/tex/empheq/EmpheqConfiguration.js'
+import '@mathjax/src/js/input/tex/enclose/EncloseConfiguration.js'
+import '@mathjax/src/js/input/tex/extpfeil/ExtpfeilConfiguration.js'
+import '@mathjax/src/js/input/tex/gensymb/GensymbConfiguration.js'
+import '@mathjax/src/js/input/tex/html/HtmlConfiguration.js'
+import '@mathjax/src/js/input/tex/mathtools/MathtoolsConfiguration.js'
+import '@mathjax/src/js/input/tex/mhchem/MhchemConfiguration.js'
+import '@mathjax/src/js/input/tex/newcommand/NewcommandConfiguration.js'
+import '@mathjax/src/js/input/tex/noerrors/NoErrorsConfiguration.js'
+import '@mathjax/src/js/input/tex/noundefined/NoUndefinedConfiguration.js'
+import '@mathjax/src/js/input/tex/physics/PhysicsConfiguration.js'
+import '@mathjax/src/js/input/tex/require/RequireConfiguration.js'
+import '@mathjax/src/js/input/tex/setoptions/SetOptionsConfiguration.js'
+import '@mathjax/src/js/input/tex/tagformat/TagFormatConfiguration.js'
+import '@mathjax/src/js/input/tex/texhtml/TexHtmlConfiguration.js'
+import '@mathjax/src/js/input/tex/textcomp/TextcompConfiguration.js'
+import '@mathjax/src/js/input/tex/textmacros/TextMacrosConfiguration.js'
+import '@mathjax/src/js/input/tex/unicode/UnicodeConfiguration.js'
+import '@mathjax/src/js/input/tex/units/UnitsConfiguration.js'
+import '@mathjax/src/js/input/tex/upgreek/UpgreekConfiguration.js'
+import '@mathjax/src/js/input/tex/verb/VerbConfiguration.js'
+
+/**
+ * All TeX packages (all v4 extensions minus autoload and bboldx).
+ *
+ * Note: `physics` redefines `\div`, `\Re`, `\Im`, and trig/log functions.
+ * `colorv2` overrides `\color` from the `color` package.
+ * Both are included to match v3's AllPackages behavior.
+ *
+ * @type {ReadonlyArray<string>}
+ */
+export const allPackages = [
+  'action',
+  'ams',
+  'amscd',
+  'base',
+  'bbm',
+  'bbox',
+  'begingroup',
+  'boldsymbol',
+  'braket',
+  'bussproofs',
+  'cancel',
+  'cases',
+  'centernot',
+  'color',
+  'colortbl',
+  'colorv2',
+  'configmacros',
+  'dsfont',
+  'empheq',
+  'enclose',
+  'extpfeil',
+  'gensymb',
+  'html',
+  'mathtools',
+  'mhchem',
+  'newcommand',
+  'noerrors',
+  'noundefined',
+  'physics',
+  'require',
+  'setoptions',
+  'tagformat',
+  'texhtml',
+  'textcomp',
+  'textmacros',
+  'unicode',
+  'units',
+  'upgreek',
+  'verb'
+]

--- a/packages/rehype-mathjax/package.json
+++ b/packages/rehype-mathjax/package.json
@@ -7,10 +7,10 @@
   ],
   "dependencies": {
     "@types/hast": "^3.0.0",
-    "@types/mathjax": "^0.0.40",
     "hast-util-to-text": "^4.0.0",
     "hastscript": "^9.0.0",
-    "mathjax-full": "^3.0.0",
+    "@mathjax/mathjax-newcm-font": "^4.0.0",
+    "@mathjax/src": "^4.0.0",
     "unified": "^11.0.0",
     "unist-util-visit-parents": "^6.0.0",
     "vfile": "^6.0.0"
@@ -60,12 +60,18 @@
     "test-api": "node --conditions development test/index.js",
     "test": "npm run build && npm run test-api"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./lib/svg.js",
+    "./lib/chtml.js",
+    "./lib/tex-packages.js",
+    "./lib/create-renderer.js"
+  ],
   "type": "module",
   "version": "7.1.0",
   "xo": {
     "prettier": true,
     "rules": {
+      "import/no-unassigned-import": "off",
       "unicorn/prefer-at": "off"
     }
   }

--- a/packages/rehype-mathjax/readme.md
+++ b/packages/rehype-mathjax/readme.md
@@ -181,7 +181,7 @@ For example:
   // …
   .use(rehypeMathjaxChtml, {
     chtml: {
-      fontURL: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/chtml/fonts/woff-v2'
+      fontURL: 'https://cdn.jsdelivr.net/npm/@mathjax/mathjax-newcm-font/chtml/woff2'
     }
   })
   // …

--- a/packages/rehype-mathjax/test/fixture/document-svg.html
+++ b/packages/rehype-mathjax/test/fixture/document-svg.html
@@ -3,8 +3,41 @@
 <title>Math!</title>
 <link rel="stylesheet" href="example.css">
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -18,22 +51,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -84,9 +159,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -109,10 +184,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
@@ -120,7 +243,7 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
 }
 </style></head>
 <body>
-<h1>Hello, <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D6FC" d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FC" xlink:href="#MJX-1-TEX-I-1D6FC"></use></g></g></g></svg></mjx-container>!</h1>
+<h1>Hello, <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-NCM-I-1D6FC" d="M310 442C241 442 179 412 124 353C69 294 41 229 41 159C41 61 107-11 205-11C274-11 342 16 410 69C425 16 456-11 502-11C538-11 589 27 589 63C589 72 584 76 573 76C566 76 560 72 557 64C549 43 528 18 505 18C488 18 479 50 479 115C479 129 482 140 488 147C515 180 539 218 558 260C583 314 598 354 602 380L602 384C599 391 593 394 586 394C581 393 575 385 568 371C547 299 518 237 479 186L479 236C479 352 421 442 310 442M403 211C403 152 404 116 405 103C340 46 274 18 207 18C150 18 122 53 122 122C122 180 155 288 178 324C216 383 260 413 309 413C340 413 361 401 374 377C381 365 386 353 391 342C399 319 403 258 403 211Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\alpha"><g data-mml-node="mi" data-latex="\alpha"><use data-c="1D6FC" xlink:href="#MJX-1-NCM-I-1D6FC"></use></g></g></g></svg></mjx-container>!</h1>
 <script src="example.js"></script>
 
 

--- a/packages/rehype-mathjax/test/fixture/double-svg.html
+++ b/packages/rehype-mathjax/test/fixture/double-svg.html
@@ -1,7 +1,40 @@
-<p>Double math <mjx-container class="MathJax" jax="SVG" display="true"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D6FC" d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FC" xlink:href="#MJX-1-TEX-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
+<p>Double math <mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-NCM-I-1D6FC" d="M310 442C241 442 179 412 124 353C69 294 41 229 41 159C41 61 107-11 205-11C274-11 342 16 410 69C425 16 456-11 502-11C538-11 589 27 589 63C589 72 584 76 573 76C566 76 560 72 557 64C549 43 528 18 505 18C488 18 479 50 479 115C479 129 482 140 488 147C515 180 539 218 558 260C583 314 598 354 602 380L602 384C599 391 593 394 586 394C581 393 575 385 568 371C547 299 518 237 479 186L479 236C479 352 421 442 310 442M403 211C403 152 404 116 405 103C340 46 274 18 207 18C150 18 122 53 122 122C122 180 155 288 178 324C216 383 260 413 309 413C340 413 361 401 374 377C381 365 386 353 391 342C399 319 403 258 403 211Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\alpha"><g data-mml-node="mi" data-latex="\alpha"><use data-c="1D6FC" xlink:href="#MJX-1-NCM-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -15,22 +48,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -81,9 +156,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -106,10 +181,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
@@ -1,9 +1,56 @@
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="CHTML" display="true" width="full" style="min-width: 8.001em;"><mjx-math width="full" display="true" class="MJX-TEX"><mjx-mtable width="full" style="min-width: 8.001em;" side="right"><mjx-table style="width: auto; min-width: 3.845em; margin: 0 2.078em;"><mjx-itable width="full"><mjx-mlabeledtr style="height: NaNem;"><mjx-mtd><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D438 TEX-I"></mjx-c></mjx-mi><mjx-mo class="mjx-n" space="4"><mjx-c class="mjx-c3D"></mjx-c></mjx-mo><mjx-mi class="mjx-i" space="4"><mjx-c class="mjx-c1D45A TEX-I"></mjx-c></mjx-mi><mjx-msup><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D450 TEX-I"></mjx-c></mjx-mi><mjx-script style="vertical-align: 0.413em;"><mjx-mn class="mjx-n" size="s"><mjx-c class="mjx-c32"></mjx-c></mjx-mn></mjx-script></mjx-msup><mjx-tstrut></mjx-tstrut></mjx-mtd></mjx-mlabeledtr></mjx-itable></mjx-table><mjx-labels style="width: 8.001em;"><mjx-itable align="right" style="right: 0;"><mjx-mtr style="height: 1.134em;"><mjx-mtd id="mjx-eqn:mass-energy_relation"><mjx-mtext class="mjx-n"><mjx-c class="mjx-c28"></mjx-c><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c29"></mjx-c></mjx-mtext><mjx-tstrut style="height: 1.134em; vertical-align: -0.25em;"></mjx-tstrut></mjx-mtd></mjx-mtr></mjx-itable></mjx-labels></mjx-mtable></mjx-math></mjx-container>
-<p>See equation <mjx-container class="MathJax" jax="CHTML"><mjx-math class="MJX-TEX"><a href="#mjx-eqn%3Amass-energy_relation"><mjx-mrow class="MathJax_ref"><mjx-mtext class="mjx-n"><mjx-c class="mjx-c28"></mjx-c><mjx-c class="mjx-c31"></mjx-c><mjx-c class="mjx-c29"></mjx-c></mjx-mtext></mjx-mrow></a></mjx-math></mjx-container>.</p>
+<mjx-container class="MathJax" jax="CHTML" overflow="overflow" display="true" width="full" style="min-width: 8.003em;"><mjx-math data-latex="\begin{equation}\label{mass-energy relation}E = m c^2\end{equation}" width="full" display="true" class="NCM-N"><mjx-mtable style="min-width: 8.003em;" data-latex="\begin{equation}\label{mass-energy relation}E = m c^2 \end{equation}" width="full" side="right"><mjx-table style="width: auto; min-width: 3.847em; margin: 0 2.078em;"><mjx-itable width="full"><mjx-mlabeledtr style="height: NaNem;"><mjx-mtd><mjx-mi data-latex="E"><mjx-c class="mjx-c1D438">𝐸</mjx-c></mjx-mi><mjx-mo space="4" data-latex="="><mjx-c class="mjx-c3D">=</mjx-c></mjx-mo><mjx-mi space="4" data-latex="m"><mjx-c class="mjx-c1D45A">𝑚</mjx-c></mjx-mi><mjx-msup data-latex="c^2"><mjx-mi data-latex="c"><mjx-c class="mjx-c1D450">𝑐</mjx-c></mjx-mi><mjx-script style="vertical-align: 0.413em;"><mjx-mn size="s" data-latex="2"><mjx-c class="mjx-c32">2</mjx-c></mjx-mn></mjx-script></mjx-msup><mjx-tstrut></mjx-tstrut></mjx-mtd></mjx-mlabeledtr></mjx-itable></mjx-table><mjx-labels style="width: 8.003em;"><mjx-itable align="right" style="right: 0;"><mjx-mtr style="height: 1.134em;"><mjx-mtd id="mjx-eqn:mass-energy_relation"><mjx-mtext data-latex="\text{(}"><mjx-c class="mjx-c28">(</mjx-c></mjx-mtext><mjx-mtext data-latex="\text{1}"><mjx-c class="mjx-c31">1</mjx-c></mjx-mtext><mjx-mtext data-latex="\text{)}"><mjx-c class="mjx-c29">)</mjx-c></mjx-mtext><mjx-tstrut style="height: 1.134em; vertical-align: -0.25em;"></mjx-tstrut></mjx-mtd></mjx-mtr></mjx-itable></mjx-labels></mjx-mtable></mjx-math></mjx-container>
+<p>See equation <mjx-container class="MathJax" jax="CHTML" overflow="overflow"><mjx-math data-latex="\eqref{mass-energy relation}" class="NCM-N"><a href="#mjx-eqn%3Amass-energy_relation"><mjx-mrow data-latex="\eqref{mass-energy relation}" class="MathJax_ref"><mjx-mtext><mjx-c class="mjx-c28" noic="true" style="padding-top: 0.748em;">(</mjx-c><mjx-c class="mjx-c31" noic="true" style="padding-top: 0.748em;">1</mjx-c><mjx-c class="mjx-c29" style="padding-top: 0.748em;">)</mjx-c></mjx-mtext></mjx-mrow></a></mjx-math></mjx-container>.</p>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="CHTML"] {
-  line-height: 0;
+  white-space: nowrap;
+}
+
+mjx-mo > mjx-c, mjx-mi > mjx-c, mjx-mn > mjx-c, mjx-ms > mjx-c, mjx-mtext > mjx-c {
+  clip-path: padding-box polygon(-1em -2px, calc(100% + 1em) -2px, calc(100% + 1em) calc(100% + 2px), -1em calc(100% + 2px));
+}
+
+mjx-stretchy-h {
+  clip-path: padding-box polygon(0 -2px, 100% -2px, 100% calc(100% + 2px), 0 calc(100% + 2px));
+  display: inline-block;
+}
+
+mjx-stretchy-v {
+  clip-path: padding-box polygon(-2px 0, calc(100% + 2px) 0, calc(100% + 2px) 100%, -2px 100%);
+  display: inline-block;
+  text-align: center;
 }
 
 mjx-container [space="1"] {
@@ -102,8 +149,22 @@ mjx-row {
   display: table-row;
 }
 
-mjx-row > * {
+mjx-row > mjx-cell, mjx-row > mjx-base, mjx-row > mjx-under, mjx-row > mjx-over, mjx-row > mjx-den {
   display: table-cell;
+}
+
+mjx-container [inline-breaks] {
+  display: inline;
+}
+
+mjx-container .mjx-selected {
+  outline: 2px solid black;
+}
+
+@media (prefers-color-scheme: dark) {
+  mjx-container .mjx-selected {
+    outline: 2px solid #C8C8C8;
+  }
 }
 
 mjx-mtext {
@@ -125,10 +186,6 @@ mjx-mphantom {
   visibility: hidden;
 }
 
-_::-webkit-full-page-media, _:future, :root mjx-container {
-  will-change: opacity;
-}
-
 mjx-math {
   display: inline-block;
   text-align: left;
@@ -139,34 +196,49 @@ mjx-math {
   font-size: 100%;
   font-size-adjust: none;
   letter-spacing: normal;
-  border-collapse: collapse;
   word-wrap: normal;
   word-spacing: normal;
-  white-space: nowrap;
   direction: ltr;
   padding: 1px 0;
-}
-
-mjx-container[jax="CHTML"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
-}
-
-mjx-container[jax="CHTML"][display="true"][width="full"] {
-  display: flex;
 }
 
 mjx-container[jax="CHTML"][display="true"] mjx-math {
   padding: 0;
 }
 
-mjx-container[jax="CHTML"][justify="left"] {
-  text-align: left;
+mjx-math[breakable] {
+  display: inline;
 }
 
-mjx-container[jax="CHTML"][justify="right"] {
-  text-align: right;
+mjx-container[jax="CHTML"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-BRK !important;
+}
+
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
 }
 
 mjx-mtable {
@@ -358,6 +430,8 @@ mjx-mtd[rowalign="axis"] {
 
 mjx-c {
   display: inline-block;
+  width: 0;
+  text-align: right;
 }
 
 mjx-utext {
@@ -375,97 +449,61 @@ mjx-mo {
   text-align: left;
 }
 
-mjx-stretchy-h {
-  display: inline-table;
-  width: 100%;
-}
-
-mjx-stretchy-h > * {
-  display: table-cell;
+mjx-stretchy-h > mjx-beg, mjx-stretchy-h > mjx-ext, mjx-stretchy-h > mjx-end, mjx-stretchy-h > mjx-mid {
+  display: inline-block;
   width: 0;
-}
-
-mjx-stretchy-h > * > mjx-c {
-  display: inline-block;
-  transform: scalex(1.0000001);
-}
-
-mjx-stretchy-h > * > mjx-c::before {
-  display: inline-block;
-  width: initial;
+  text-align: right;
 }
 
 mjx-stretchy-h > mjx-ext {
-  /* IE */ overflow: hidden;
-  /* others */ overflow: clip visible;
+  clip-path: padding-box polygon(0 -1em, 100% -1em, 100% calc(100% + 1em), 0 calc(100% + 1em));
   width: 100%;
+  border: 0px solid transparent;
+  box-sizing: border-box;
+  text-align: left;
 }
 
-mjx-stretchy-h > mjx-ext > mjx-c::before {
-  transform: scalex(500);
-}
-
-mjx-stretchy-h > mjx-ext > mjx-c {
-  width: 0;
-}
-
-mjx-stretchy-h > mjx-beg > mjx-c {
-  margin-right: -.1em;
-}
-
-mjx-stretchy-h > mjx-end > mjx-c {
-  margin-left: -.1em;
-}
-
-mjx-stretchy-v {
-  display: inline-block;
-}
-
-mjx-stretchy-v > * {
+mjx-stretchy-v > mjx-beg, mjx-stretchy-v > mjx-ext, mjx-stretchy-v > mjx-end, mjx-stretchy-v > mjx-mid {
   display: block;
-}
-
-mjx-stretchy-v > mjx-beg {
   height: 0;
+  margin: 0 auto;
 }
 
-mjx-stretchy-v > mjx-end > mjx-c {
+mjx-stretchy-v > mjx-ext > mjx-spacer {
   display: block;
-}
-
-mjx-stretchy-v > * > mjx-c {
-  transform: scaley(1.0000001);
-  transform-origin: left center;
-  overflow: hidden;
 }
 
 mjx-stretchy-v > mjx-ext {
-  display: block;
+  clip-path: padding-box polygon(-1em 0, calc(100% + 1em) 0, calc(100% + 1em) 100%, -1em 100%);
   height: 100%;
+  border: 0.1px solid transparent;
   box-sizing: border-box;
-  border: 0px solid transparent;
-  /* IE */ overflow: hidden;
-  /* others */ overflow: visible clip;
-}
-
-mjx-stretchy-v > mjx-ext > mjx-c::before {
-  width: initial;
-  box-sizing: border-box;
-}
-
-mjx-stretchy-v > mjx-ext > mjx-c {
-  transform: scaleY(500) translateY(.075em);
-  overflow: visible;
+  white-space: pre;
 }
 
 mjx-mark {
   display: inline-block;
-  height: 0px;
+  height: 0;
 }
 
 mjx-msup {
   display: inline-block;
   text-align: left;
+}
+
+mjx-msubsup {
+  display: inline-block;
+  text-align: left;
+}
+
+mjx-script {
+  display: inline-block;
+  padding-right: .05em;
+  padding-left: .033em;
+}
+
+mjx-script > mjx-spacer {
+  display: block;
 }
 
 mjx-mn {
@@ -478,246 +516,512 @@ mjx-mrow {
   text-align: left;
 }
 
-mjx-c::before {
+mjx-linestack, mjx-mrow[break-top] {
+  display: inline-table;
+  width: 100%;
+}
+
+mjx-linestack[break-align="bottom"], mjx-mrow[break-top][break-align="bottom"] {
+  display: inline-block;
+}
+
+mjx-linestack[break-align="middle"], mjx-mrow[break-top][break-align="middle"] {
+  vertical-align: middle;
+}
+
+mjx-linestack[break-align="center"], mjx-mrow[break-top][break-align="center"] {
+  vertical-align: middle;
+}
+
+mjx-linestack[breakable] {
+  display: inline;
+}
+
+mjx-linestack[breakable] > mjx-linebox {
+  display: inline;
+}
+
+mjx-linestack[breakable] > mjx-linebox::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-linestack[breakable] > mjx-linebox::after {
+  white-space: normal;
+  content: " ";
+  letter-spacing: -.999em;
+  font-family: MJX-BRK;
+}
+
+mjx-linestack[breakable] > mjx-linebox:first-of-type::before {
+  display: none;
+}
+
+mjx-linestack[breakable] > mjx-linebox:last-of-type::after {
+  display: none;
+}
+
+mjx-linebox {
   display: block;
-  width: 0;
 }
 
-.MJX-TEX {
-  font-family: MJXZERO, MJXTEX;
+mjx-linebox[align="left"] {
+  text-align: left;
 }
 
-.TEX-B {
-  font-family: MJXZERO, MJXTEX-B;
+mjx-linebox[align="center"] {
+  text-align: center;
 }
 
-.TEX-I {
-  font-family: MJXZERO, MJXTEX-I;
+mjx-linebox[align="right"] {
+  text-align: right;
 }
 
-.TEX-MI {
-  font-family: MJXZERO, MJXTEX-MI;
+mjx-linestrut {
+  display: inline-block;
+  height: 1em;
+  vertical-align: -.25em;
 }
 
-.TEX-BI {
-  font-family: MJXZERO, MJXTEX-BI;
+mjx-container[jax="CHTML"] > mjx-math.NCM-N[breakable] > * {
+  font-family: MJX-NCM-ZERO, MJX-NCM-N;
 }
 
-.TEX-S1 {
-  font-family: MJXZERO, MJXTEX-S1;
+.NCM-N {
+  font-family: MJX-NCM-ZERO, MJX-NCM-N;
 }
 
-.TEX-S2 {
-  font-family: MJXZERO, MJXTEX-S2;
+.NCM-B {
+  font-family: MJX-NCM-ZERO, MJX-NCM-B;
 }
 
-.TEX-S3 {
-  font-family: MJXZERO, MJXTEX-S3;
+.NCM-I {
+  font-family: MJX-NCM-ZERO, MJX-NCM-I;
 }
 
-.TEX-S4 {
-  font-family: MJXZERO, MJXTEX-S4;
+.NCM-BI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-BI;
 }
 
-.TEX-A {
-  font-family: MJXZERO, MJXTEX-A;
+.NCM-DS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-DS;
 }
 
-.TEX-C {
-  font-family: MJXZERO, MJXTEX-C;
+.NCM-F {
+  font-family: MJX-NCM-ZERO, MJX-NCM-F;
 }
 
-.TEX-CB {
-  font-family: MJXZERO, MJXTEX-CB;
+.NCM-FB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-FB;
 }
 
-.TEX-FR {
-  font-family: MJXZERO, MJXTEX-FR;
+.NCM-SS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SS;
 }
 
-.TEX-FRB {
-  font-family: MJXZERO, MJXTEX-FRB;
+.NCM-SSB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSB;
 }
 
-.TEX-SS {
-  font-family: MJXZERO, MJXTEX-SS;
+.NCM-SSI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSI;
 }
 
-.TEX-SSB {
-  font-family: MJXZERO, MJXTEX-SSB;
+.NCM-SSBI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSBI;
 }
 
-.TEX-SSI {
-  font-family: MJXZERO, MJXTEX-SSI;
+.NCM-M {
+  font-family: MJX-NCM-ZERO, MJX-NCM-M;
 }
 
-.TEX-SC {
-  font-family: MJXZERO, MJXTEX-SC;
+.NCM-SO {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SO;
 }
 
-.TEX-T {
-  font-family: MJXZERO, MJXTEX-T;
+.NCM-LO {
+  font-family: MJX-NCM-ZERO, MJX-NCM-LO;
 }
 
-.TEX-V {
-  font-family: MJXZERO, MJXTEX-V;
+.NCM-S3 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S3;
 }
 
-.TEX-VB {
-  font-family: MJXZERO, MJXTEX-VB;
+.NCM-S4 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S4;
 }
 
-mjx-stretchy-v mjx-c, mjx-stretchy-h mjx-c {
-  font-family: MJXZERO, MJXTEX-S1, MJXTEX-S4, MJXTEX, MJXTEX-A ! important;
+.NCM-S5 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S5;
 }
 
-@font-face /* 0 */ {
-  font-family: MJXZERO;
-  src: url("place/to/fonts/MathJax_Zero.woff") format("woff");
+.NCM-S6 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S6;
 }
 
-@font-face /* 1 */ {
-  font-family: MJXTEX;
-  src: url("place/to/fonts/MathJax_Main-Regular.woff") format("woff");
+.NCM-S7 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S7;
 }
 
-@font-face /* 2 */ {
-  font-family: MJXTEX-B;
-  src: url("place/to/fonts/MathJax_Main-Bold.woff") format("woff");
+.NCM-MI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MI;
 }
 
-@font-face /* 3 */ {
-  font-family: MJXTEX-I;
-  src: url("place/to/fonts/MathJax_Math-Italic.woff") format("woff");
+.NCM-C {
+  font-family: MJX-NCM-ZERO, MJX-NCM-C;
 }
 
-@font-face /* 4 */ {
-  font-family: MJXTEX-MI;
-  src: url("place/to/fonts/MathJax_Main-Italic.woff") format("woff");
+.NCM-CB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-CB;
 }
 
-@font-face /* 5 */ {
-  font-family: MJXTEX-BI;
-  src: url("place/to/fonts/MathJax_Math-BoldItalic.woff") format("woff");
+.NCM-OS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-OS;
 }
 
-@font-face /* 6 */ {
-  font-family: MJXTEX-S1;
-  src: url("place/to/fonts/MathJax_Size1-Regular.woff") format("woff");
+.NCM-OB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-OB;
 }
 
-@font-face /* 7 */ {
-  font-family: MJXTEX-S2;
-  src: url("place/to/fonts/MathJax_Size2-Regular.woff") format("woff");
+.NCM-V {
+  font-family: MJX-NCM-ZERO, MJX-NCM-V;
 }
 
-@font-face /* 8 */ {
-  font-family: MJXTEX-S3;
-  src: url("place/to/fonts/MathJax_Size3-Regular.woff") format("woff");
+.NCM-LT {
+  font-family: MJX-NCM-ZERO, MJX-NCM-LT;
 }
 
-@font-face /* 9 */ {
-  font-family: MJXTEX-S4;
-  src: url("place/to/fonts/MathJax_Size4-Regular.woff") format("woff");
+.NCM-RB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-RB;
 }
 
-@font-face /* 10 */ {
-  font-family: MJXTEX-A;
-  src: url("place/to/fonts/MathJax_AMS-Regular.woff") format("woff");
+.NCM-EM {
+  font-family: MJX-NCM-ZERO, MJX-NCM-EM;
 }
 
-@font-face /* 11 */ {
-  font-family: MJXTEX-C;
-  src: url("place/to/fonts/MathJax_Calligraphic-Regular.woff") format("woff");
+.NCM-B-a {
+  font-family: MJX-NCM-ZERO, MJX-NCM-B-a;
 }
 
-@font-face /* 12 */ {
-  font-family: MJXTEX-CB;
-  src: url("place/to/fonts/MathJax_Calligraphic-Bold.woff") format("woff");
+.NCM-U {
+  font-family: MJX-NCM-ZERO, MJX-NCM-U;
 }
 
-@font-face /* 13 */ {
-  font-family: MJXTEX-FR;
-  src: url("place/to/fonts/MathJax_Fraktur-Regular.woff") format("woff");
+.NCM-U-a {
+  font-family: MJX-NCM-ZERO, MJX-NCM-U-a;
 }
 
-@font-face /* 14 */ {
-  font-family: MJXTEX-FRB;
-  src: url("place/to/fonts/MathJax_Fraktur-Bold.woff") format("woff");
+.NCM-S {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S;
 }
 
-@font-face /* 15 */ {
-  font-family: MJXTEX-SS;
-  src: url("place/to/fonts/MathJax_SansSerif-Regular.woff") format("woff");
+.NCM-SB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SB;
 }
 
-@font-face /* 16 */ {
-  font-family: MJXTEX-SSB;
-  src: url("place/to/fonts/MathJax_SansSerif-Bold.woff") format("woff");
+.NCM-MM {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MM;
 }
 
-@font-face /* 17 */ {
-  font-family: MJXTEX-SSI;
-  src: url("place/to/fonts/MathJax_SansSerif-Italic.woff") format("woff");
+@font-face /* NCM-MM */ {
+  font-family: MJX-NCM-MM;
+  src: url("place/to/fonts/mjx-ncm-mm.woff2") format("woff2");
 }
 
-@font-face /* 18 */ {
-  font-family: MJXTEX-SC;
-  src: url("place/to/fonts/MathJax_Script-Regular.woff") format("woff");
+.NCM-SY {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SY;
 }
 
-@font-face /* 19 */ {
-  font-family: MJXTEX-T;
-  src: url("place/to/fonts/MathJax_Typewriter-Regular.woff") format("woff");
+@font-face /* NCM-SY */ {
+  font-family: MJX-NCM-SY;
+  src: url("place/to/fonts/mjx-ncm-sy.woff2") format("woff2");
 }
 
-@font-face /* 20 */ {
-  font-family: MJXTEX-V;
-  src: url("place/to/fonts/MathJax_Vector-Regular.woff") format("woff");
+.NCM-AR {
+  font-family: MJX-NCM-ZERO, MJX-NCM-AR;
 }
 
-@font-face /* 21 */ {
-  font-family: MJXTEX-VB;
-  src: url("place/to/fonts/MathJax_Vector-Bold.woff") format("woff");
+.NCM-ARL {
+  font-family: MJX-NCM-ZERO, MJX-NCM-ARL;
 }
 
-mjx-c.mjx-c28::before {
-  padding: 0.75em 0.389em 0.25em 0;
-  content: "(";
+@font-face /* NCM-AR */ {
+  font-family: MJX-NCM-AR;
+  src: url("place/to/fonts/mjx-ncm-ar.woff2") format("woff2");
 }
 
-mjx-c.mjx-c31::before {
+@font-face /* NCM-ARL */ {
+  font-family: MJX-NCM-ARL;
+  src: url("place/to/fonts/mjx-ncm-arl.woff2") format("woff2");
+}
+
+.NCM-MAR {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MAR;
+}
+
+@font-face /* NCM-MAR */ {
+  font-family: MJX-NCM-MAR;
+  src: url("place/to/fonts/mjx-ncm-mar.woff2") format("woff2");
+}
+
+.NCM-SH {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SH;
+}
+
+.NCM-SHB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHB;
+}
+
+.NCM-SHI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHI;
+}
+
+.NCM-SHBI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHBI;
+}
+
+@font-face /* NCM-SH */ {
+  font-family: MJX-NCM-SH;
+  src: url("place/to/fonts/mjx-ncm-sh.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHB */ {
+  font-family: MJX-NCM-SHB;
+  src: url("place/to/fonts/mjx-ncm-shb.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHI */ {
+  font-family: MJX-NCM-SHI;
+  src: url("place/to/fonts/mjx-ncm-shi.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHBI */ {
+  font-family: MJX-NCM-SHBI;
+  src: url("place/to/fonts/mjx-ncm-shbi.woff2") format("woff2");
+}
+
+.NCM-MSH {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MSH;
+}
+
+@font-face /* NCM-MSH */ {
+  font-family: MJX-NCM-MSH;
+  src: url("place/to/fonts/mjx-ncm-msh.woff2") format("woff2");
+}
+
+.NCM-VX {
+  font-family: MJX-NCM-ZERO, MJX-NCM-VX;
+}
+
+@font-face /* NCM-VX */ {
+  font-family: MJX-NCM-VX;
+  src: url("place/to/fonts/mjx-ncm-vx.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-ZERO */ {
+  font-family: MJX-NCM-ZERO;
+  src: url("place/to/fonts/mjx-ncm-zero.woff2") format("woff2");
+}
+
+@font-face /* MJX-BRK */ {
+  font-family: MJX-BRK;
+  src: url("place/to/fonts/mjx-ncm-brk.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-N */ {
+  font-family: MJX-NCM-N;
+  src: url("place/to/fonts/mjx-ncm-n.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-B */ {
+  font-family: MJX-NCM-B;
+  src: url("place/to/fonts/mjx-ncm-b.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-I */ {
+  font-family: MJX-NCM-I;
+  src: url("place/to/fonts/mjx-ncm-i.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-BI */ {
+  font-family: MJX-NCM-BI;
+  src: url("place/to/fonts/mjx-ncm-bi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-DS */ {
+  font-family: MJX-NCM-DS;
+  src: url("place/to/fonts/mjx-ncm-ds.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-F */ {
+  font-family: MJX-NCM-F;
+  src: url("place/to/fonts/mjx-ncm-f.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-FB */ {
+  font-family: MJX-NCM-FB;
+  src: url("place/to/fonts/mjx-ncm-fb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SS */ {
+  font-family: MJX-NCM-SS;
+  src: url("place/to/fonts/mjx-ncm-ss.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSB */ {
+  font-family: MJX-NCM-SSB;
+  src: url("place/to/fonts/mjx-ncm-ssb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSI */ {
+  font-family: MJX-NCM-SSI;
+  src: url("place/to/fonts/mjx-ncm-ssi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSBI */ {
+  font-family: MJX-NCM-SSBI;
+  src: url("place/to/fonts/mjx-ncm-ssbi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-M */ {
+  font-family: MJX-NCM-M;
+  src: url("place/to/fonts/mjx-ncm-m.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SO */ {
+  font-family: MJX-NCM-SO;
+  src: url("place/to/fonts/mjx-ncm-so.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-LO */ {
+  font-family: MJX-NCM-LO;
+  src: url("place/to/fonts/mjx-ncm-lo.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S3 */ {
+  font-family: MJX-NCM-S3;
+  src: url("place/to/fonts/mjx-ncm-s3.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S4 */ {
+  font-family: MJX-NCM-S4;
+  src: url("place/to/fonts/mjx-ncm-s4.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S5 */ {
+  font-family: MJX-NCM-S5;
+  src: url("place/to/fonts/mjx-ncm-s5.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S6 */ {
+  font-family: MJX-NCM-S6;
+  src: url("place/to/fonts/mjx-ncm-s6.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S7 */ {
+  font-family: MJX-NCM-S7;
+  src: url("place/to/fonts/mjx-ncm-s7.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-MI */ {
+  font-family: MJX-NCM-MI;
+  src: url("place/to/fonts/mjx-ncm-mi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-C */ {
+  font-family: MJX-NCM-C;
+  src: url("place/to/fonts/mjx-ncm-c.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-CB */ {
+  font-family: MJX-NCM-CB;
+  src: url("place/to/fonts/mjx-ncm-cb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-OS */ {
+  font-family: MJX-NCM-OS;
+  src: url("place/to/fonts/mjx-ncm-os.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-OB */ {
+  font-family: MJX-NCM-OB;
+  src: url("place/to/fonts/mjx-ncm-ob.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-V */ {
+  font-family: MJX-NCM-V;
+  src: url("place/to/fonts/mjx-ncm-v.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-LT */ {
+  font-family: MJX-NCM-LT;
+  src: url("place/to/fonts/mjx-ncm-lt.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-RB */ {
+  font-family: MJX-NCM-RB;
+  src: url("place/to/fonts/mjx-ncm-rb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-EM */ {
+  font-family: MJX-NCM-EM;
+  src: url("place/to/fonts/mjx-ncm-em.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-B-a */ {
+  font-family: MJX-NCM-B-a;
+  src: url("place/to/fonts/mjx-ncm-b-a.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-U */ {
+  font-family: MJX-NCM-U;
+  src: url("place/to/fonts/mjx-ncm-u.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-U-a */ {
+  font-family: MJX-NCM-U-a;
+  src: url("place/to/fonts/mjx-ncm-u-a.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S */ {
+  font-family: MJX-NCM-S;
+  src: url("place/to/fonts/mjx-ncm-s.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SB */ {
+  font-family: MJX-NCM-SB;
+  src: url("place/to/fonts/mjx-ncm-sb.woff2") format("woff2");
+}
+
+mjx-c.mjx-c28 {
+  padding: 0.748em 0.389em 0.248em 0;
+}
+
+mjx-c.mjx-c31 {
   padding: 0.666em 0.5em 0 0;
-  content: "1";
 }
 
-mjx-c.mjx-c29::before {
-  padding: 0.75em 0.389em 0.25em 0;
-  content: ")";
+mjx-c.mjx-c29 {
+  padding: 0.748em 0.389em 0.248em 0;
 }
 
-mjx-c.mjx-c1D438.TEX-I::before {
-  padding: 0.68em 0.764em 0 0;
-  content: "E";
+mjx-c.mjx-c1D438 {
+  padding: 0.68em 0.766em 0 0;
 }
 
-mjx-c.mjx-c3D::before {
-  padding: 0.583em 0.778em 0.082em 0;
-  content: "=";
+mjx-c.mjx-c3D {
+  padding: 0.367em 0.778em 0 0;
 }
 
-mjx-c.mjx-c1D45A.TEX-I::before {
+mjx-c.mjx-c1D45A {
   padding: 0.442em 0.878em 0.011em 0;
-  content: "m";
 }
 
-mjx-c.mjx-c1D450.TEX-I::before {
+mjx-c.mjx-c1D450 {
   padding: 0.442em 0.433em 0.011em 0;
-  content: "c";
 }
 
-mjx-c.mjx-c32::before {
+mjx-c.mjx-c32 {
   padding: 0.666em 0.5em 0 0;
-  content: "2";
 }
 </style>

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1-svg.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1-svg.html
@@ -1,9 +1,42 @@
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="SVG" display="true" width="full" style="min-width: 18.102ex;"><svg style="vertical-align: -0.717ex; min-width: 18.102ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D438" d="M492 213Q472 213 472 226Q472 230 477 250T482 285Q482 316 461 323T364 330H312Q311 328 277 192T243 52Q243 48 254 48T334 46Q428 46 458 48T518 61Q567 77 599 117T670 248Q680 270 683 272Q690 274 698 274Q718 274 718 261Q613 7 608 2Q605 0 322 0H133Q31 0 31 11Q31 13 34 25Q38 41 42 43T65 46Q92 46 125 49Q139 52 144 61Q146 66 215 342T285 622Q285 629 281 629Q273 632 228 634H197Q191 640 191 642T193 659Q197 676 203 680H757Q764 676 764 669Q764 664 751 557T737 447Q735 440 717 440H705Q698 445 698 453L701 476Q704 500 704 528Q704 558 697 578T678 609T643 625T596 632T532 634H485Q397 633 392 631Q388 629 386 622Q385 619 355 499T324 377Q347 376 372 376H398Q464 376 489 391T534 472Q538 488 540 490T557 493Q562 493 565 493T570 492T572 491T574 487T577 483L544 351Q511 218 508 216Q505 213 492 213Z"></path><path id="MJX-1-TEX-N-3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path><path id="MJX-1-TEX-I-1D45A" d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z"></path><path id="MJX-1-TEX-I-1D450" d="M34 159Q34 268 120 355T306 442Q362 442 394 418T427 355Q427 326 408 306T360 285Q341 285 330 295T319 325T330 359T352 380T366 386H367Q367 388 361 392T340 400T306 404Q276 404 249 390Q228 381 206 359Q162 315 142 235T121 119Q121 73 147 50Q169 26 205 26H209Q321 26 394 111Q403 121 406 121Q410 121 419 112T429 98T420 83T391 55T346 25T282 0T202 -11Q127 -11 81 37T34 159Z"></path><path id="MJX-1-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path><path id="MJX-1-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-1-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-1-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(0.0181,-0.0181) translate(0, -817)"><g data-mml-node="math"><g data-mml-node="mtable" transform="translate(2078,0) translate(-2078,0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="1922.6 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0,-67)"><g data-mml-node="mtd"><g data-mml-node="mi"><use data-c="1D438" xlink:href="#MJX-1-TEX-I-1D438"></use></g><g data-mml-node="mo" transform="translate(1041.8,0)"><use data-c="3D" xlink:href="#MJX-1-TEX-N-3D"></use></g><g data-mml-node="mi" transform="translate(2097.6,0)"><use data-c="1D45A" xlink:href="#MJX-1-TEX-I-1D45A"></use></g><g data-mml-node="msup" transform="translate(2975.6,0)"><g data-mml-node="mi"><use data-c="1D450" xlink:href="#MJX-1-TEX-I-1D450"></use></g><g data-mml-node="mn" transform="translate(466,413) scale(0.707)"><use data-c="32" xlink:href="#MJX-1-TEX-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn:mass-energy_relation" transform="translate(0,683)"><text data-id-align="true"></text><g data-idbox="true" transform="translate(0,-750)"><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-1-TEX-N-28"></use><use data-c="31" xlink:href="#MJX-1-TEX-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-1-TEX-N-29" transform="translate(889,0)"></use></g></g></g></g></svg></g></g></g></g></svg></mjx-container>
-<p>See equation <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 1278 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-2-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><a href="#mjx-eqn%3Amass-energy_relation"><g data-mml-node="mrow" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="1000" y="-250"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-2-TEX-N-28"></use><use data-c="31" xlink:href="#MJX-2-TEX-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-2-TEX-N-29" transform="translate(889,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
+<mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true" width="full" style="min-width: 18.107ex;"><svg style="vertical-align: -0.717ex; min-width: 18.107ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink" data-mjx-view-box="0 -817 8003.1 1133.9"><defs><path id="MJX-1-NCM-I-1D438" d="M199 656C199 646 210 641 231 641C271 641 291 637 291 628C291 625 289 618 286 605L156 82C151 60 141 47 126 42C119 40 101 39 70 39C48 39 38 37 38 16C38 5 49 0 70 0L583 0C607 0 609 2 617 19L657 109C684 171 703 217 714 248C712 257 709 263 698 263C691 263 685 258 681 249C656 190 632 145 608 113C568 59 509 39 415 39L270 39C260 39 253 39 249 40C243 40 240 42 240 45C240 47 242 54 245 67L311 334L406 334C453 334 478 328 483 315C485 310 486 303 486 293C486 280 484 264 479 245C477 240 476 236 476 233C476 223 482 218 493 218C502 218 508 226 512 241L568 473C568 483 563 488 552 488C544 488 538 481 535 467C525 428 512 403 495 391C478 379 450 373 409 373L321 373L379 606C387 640 387 641 429 641L568 641C619 641 654 636 673 626C701 611 715 581 715 536C715 519 714 501 711 484C711 482 711 479 710 475L710 466C710 455 715 450 725 450C735 450 741 459 743 478L763 649C766 677 759 680 732 680L233 680C210 680 199 679 199 656Z"></path><path id="MJX-1-NCM-N-3D" d="M698 367L80 367C64 367 56 359 56 344C56 329 64 321 80 321L698 321C714 321 722 329 722 344C722 356 711 367 698 367M698 179L80 179C64 179 56 171 56 156C56 141 64 133 80 133L698 133C714 133 722 141 722 156C722 169 711 179 698 179Z"></path><path id="MJX-1-NCM-I-1D45A" d="M657 442C596 442 543 412 498 353C489 412 451 442 383 442C324 442 273 416 231 363C223 407 188 442 137 442C96 442 66 409 45 344C34 312 29 293 29 287C29 278 34 273 45 273C50 273 53 274 56 276C61 285 64 292 66 299C84 375 107 413 134 413C152 413 161 399 161 371C161 358 156 331 145 290L88 63C84 51 79 25 79 19C79-1 90-11 111-11C131-11 145-1 152 19C153 24 160 49 171 92L192 181L222 295C233 318 250 341 272 365C301 397 337 413 380 413C413 413 429 391 429 348C429 335 424 308 414 267L387 153C380 124 364 64 356 32C355 25 354 21 354 19C354-1 365-11 387-11C398-11 406-8 413-1C428 14 429 21 435 48L494 285C497 298 511 321 535 353C565 393 605 413 654 413C687 413 703 391 703 348C703 309 683 236 642 129C633 106 629 87 629 74C629 25 666-11 714-11C759-11 793 14 818 64C838 104 848 131 848 144C848 153 843 158 832 158C825 157 818 148 813 137C791 58 759 18 716 18C703 18 696 28 696 47C696 62 702 84 714 115C755 222 775 295 775 333C775 404 728 442 657 442Z"></path><path id="MJX-1-NCM-I-1D450" d="M328 325C328 300 341 287 368 287C404 287 427 318 427 354C427 410 368 442 308 442C239 442 176 412 122 353C68 294 41 229 41 159C41 61 106-11 204-11C257-11 304 2 345 27C379 48 404 69 420 90C427 99 430 106 430 109C430 120 425 126 414 126C409 126 404 122 398 114C365 70 324 42 277 30C246 22 223 18 206 18C149 18 121 53 121 122C121 184 150 274 174 317C198 361 249 413 308 413C346 413 372 402 386 381C355 378 328 358 328 325Z"></path><path id="MJX-1-NCM-N-32" d="M237 666C186 666 143 648 106 612C69 576 50 534 50 483C50 449 75 424 106 424C136 424 161 450 161 480C161 513 137 536 105 536C102 536 100 536 98 535C117 584 161 627 224 627C306 627 352 556 352 470C352 403 318 331 250 255L62 43C49 28 50 29 50 0L421 0L450 180L417 180C409 129 402 100 396 91C391 86 361 84 306 84L139 84L236 179C304 243 390 312 419 365C439 400 449 435 449 470C449 588 357 666 237 666Z"></path><path id="MJX-1-NCM-N-28" d="M318-248C327-248 332-243 332-234C332-231 330-227 327-223C275-183 233-117 202-26C175 53 161 131 161 208L161 292C161 369 175 447 202 526C233 617 275 683 327 723C330 726 332 730 332 734C332 743 327 748 318 748C317 748 314 747 311 745C251 699 201 631 160 540C121 453 101 371 101 292L101 208C101 129 121 47 160-40C201-131 251-199 311-245C314-247 317-248 318-248Z"></path><path id="MJX-1-NCM-N-31" d="M269 666C228 624 168 603 89 603L89 564C141 564 184 572 217 588L217 82C217 64 213 52 204 47C195 42 170 39 130 39L95 39L95 0C120 2 174 3 257 3C340 3 394 2 419 0L419 39L384 39C343 39 318 42 310 47C302 52 297 64 297 82L297 636C297 660 295 666 269 666Z"></path><path id="MJX-1-NCM-N-29" d="M78-245C138-199 188-131 229-40C268 47 288 129 288 208L288 292C288 371 268 453 229 540C188 631 138 699 78 745C75 747 72 748 71 748C62 748 57 743 57 734C57 730 59 726 62 723C114 683 156 617 187 526C214 447 228 369 228 292L228 208C228 131 214 53 187-26C156-117 114-183 62-223C59-227 57-231 57-234C57-243 62-248 71-248C72-248 75-247 78-245Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(0.0181,-0.0181) translate(0, -817)"><g data-mml-node="math" data-latex="\begin{equation}\label{mass-energy relation}E = m c^2\end{equation}"><g data-mml-node="mtable" data-latex="\begin{equation}\label{mass-energy relation}E = m c^2 \end{equation}" transform="translate(2078,0) translate(-2078,0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="1923.6 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0,-67)"><g data-mml-node="mtd"><g data-mml-node="mi" data-latex="E"><use data-c="1D438" xlink:href="#MJX-1-NCM-I-1D438"></use></g><g data-mml-node="mo" data-latex="=" transform="translate(1043.8,0)"><use data-c="3D" xlink:href="#MJX-1-NCM-N-3D"></use></g><g data-mml-node="mi" data-latex="m" transform="translate(2099.6,0)"><use data-c="1D45A" xlink:href="#MJX-1-NCM-I-1D45A"></use></g><g data-mml-node="msup" data-latex="c^2" transform="translate(2977.6,0)"><g data-mml-node="mi" data-latex="c"><use data-c="1D450" xlink:href="#MJX-1-NCM-I-1D450"></use></g><g data-mml-node="mn" transform="translate(466,413) scale(0.707)" data-latex="2"><use data-c="32" xlink:href="#MJX-1-NCM-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn:mass-energy_relation" transform="translate(0,681)"><text data-id-align="true"></text><g data-idbox="true" transform="translate(0,-748)"><g data-mml-node="mtext" data-latex="\text{(}"><use data-c="28" xlink:href="#MJX-1-NCM-N-28"></use></g><g data-mml-node="mtext" data-latex="\text{1}" transform="translate(389,0)"><use data-c="31" xlink:href="#MJX-1-NCM-N-31"></use></g><g data-mml-node="mtext" data-latex="\text{)}" transform="translate(889,0)"><use data-c="29" xlink:href="#MJX-1-NCM-N-29"></use></g></g></g></g></svg></g></g></g></g></svg></mjx-container>
+<p>See equation <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.561ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.253ex" role="img" focusable="false" viewBox="0 -748 1278 996" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-NCM-N-28" d="M318-248C327-248 332-243 332-234C332-231 330-227 327-223C275-183 233-117 202-26C175 53 161 131 161 208L161 292C161 369 175 447 202 526C233 617 275 683 327 723C330 726 332 730 332 734C332 743 327 748 318 748C317 748 314 747 311 745C251 699 201 631 160 540C121 453 101 371 101 292L101 208C101 129 121 47 160-40C201-131 251-199 311-245C314-247 317-248 318-248Z"></path><path id="MJX-2-NCM-N-31" d="M269 666C228 624 168 603 89 603L89 564C141 564 184 572 217 588L217 82C217 64 213 52 204 47C195 42 170 39 130 39L95 39L95 0C120 2 174 3 257 3C340 3 394 2 419 0L419 39L384 39C343 39 318 42 310 47C302 52 297 64 297 82L297 636C297 660 295 666 269 666Z"></path><path id="MJX-2-NCM-N-29" d="M78-245C138-199 188-131 229-40C268 47 288 129 288 208L288 292C288 371 268 453 229 540C188 631 138 699 78 745C75 747 72 748 71 748C62 748 57 743 57 734C57 730 59 726 62 723C114 683 156 617 187 526C214 447 228 369 228 292L228 208C228 131 214 53 187-26C156-117 114-183 62-223C59-227 57-231 57-234C57-243 62-248 71-248C72-248 75-247 78-245Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\eqref{mass-energy relation}"><a href="#mjx-eqn%3Amass-energy_relation"><g data-mml-node="mrow" data-latex="\eqref{mass-energy relation}" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="996" x="0" y="-248"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-2-NCM-N-28"></use><use data-c="31" xlink:href="#MJX-2-NCM-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-2-NCM-N-29" transform="translate(889,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -17,22 +50,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -83,9 +158,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -108,10 +183,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-2-svg.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-2-svg.html
@@ -1,10 +1,43 @@
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="SVG" display="true" width="full" style="min-width: 21.296ex;"><svg style="vertical-align: -0.717ex; min-width: 21.296ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D44E" d="M33 157Q33 258 109 349T280 441Q331 441 370 392Q386 422 416 422Q429 422 439 414T449 394Q449 381 412 234T374 68Q374 43 381 35T402 26Q411 27 422 35Q443 55 463 131Q469 151 473 152Q475 153 483 153H487Q506 153 506 144Q506 138 501 117T481 63T449 13Q436 0 417 -8Q409 -10 393 -10Q359 -10 336 5T306 36L300 51Q299 52 296 50Q294 48 292 46Q233 -10 172 -10Q117 -10 75 30T33 157ZM351 328Q351 334 346 350T323 385T277 405Q242 405 210 374T160 293Q131 214 119 129Q119 126 119 118T118 106Q118 61 136 44T179 26Q217 26 254 59T298 110Q300 114 325 217T351 328Z"></path><path id="MJX-1-TEX-N-32" d="M109 429Q82 429 66 447T50 491Q50 562 103 614T235 666Q326 666 387 610T449 465Q449 422 429 383T381 315T301 241Q265 210 201 149L142 93L218 92Q375 92 385 97Q392 99 409 186V189H449V186Q448 183 436 95T421 3V0H50V19V31Q50 38 56 46T86 81Q115 113 136 137Q145 147 170 174T204 211T233 244T261 278T284 308T305 340T320 369T333 401T340 431T343 464Q343 527 309 573T212 619Q179 619 154 602T119 569T109 550Q109 549 114 549Q132 549 151 535T170 489Q170 464 154 447T109 429Z"></path><path id="MJX-1-TEX-N-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"></path><path id="MJX-1-TEX-I-1D44F" d="M73 647Q73 657 77 670T89 683Q90 683 161 688T234 694Q246 694 246 685T212 542Q204 508 195 472T180 418L176 399Q176 396 182 402Q231 442 283 442Q345 442 383 396T422 280Q422 169 343 79T173 -11Q123 -11 82 27T40 150V159Q40 180 48 217T97 414Q147 611 147 623T109 637Q104 637 101 637H96Q86 637 83 637T76 640T73 647ZM336 325V331Q336 405 275 405Q258 405 240 397T207 376T181 352T163 330L157 322L136 236Q114 150 114 114Q114 66 138 42Q154 26 178 26Q211 26 245 58Q270 81 285 114T318 219Q336 291 336 325Z"></path><path id="MJX-1-TEX-N-3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path><path id="MJX-1-TEX-I-1D450" d="M34 159Q34 268 120 355T306 442Q362 442 394 418T427 355Q427 326 408 306T360 285Q341 285 330 295T319 325T330 359T352 380T366 386H367Q367 388 361 392T340 400T306 404Q276 404 249 390Q228 381 206 359Q162 315 142 235T121 119Q121 73 147 50Q169 26 205 26H209Q321 26 394 111Q403 121 406 121Q410 121 419 112T429 98T420 83T391 55T346 25T282 0T202 -11Q127 -11 81 37T34 159Z"></path><path id="MJX-1-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-1-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-1-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(0.0181,-0.0181) translate(0, -817)"><g data-mml-node="math"><g data-mml-node="mtable" transform="translate(2078,0) translate(-2078,0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="2628.3 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0,-67)"><g data-mml-node="mtd"><g data-mml-node="msup"><g data-mml-node="mi"><use data-c="1D44E" xlink:href="#MJX-1-TEX-I-1D44E"></use></g><g data-mml-node="mn" transform="translate(562,413) scale(0.707)"><use data-c="32" xlink:href="#MJX-1-TEX-N-32"></use></g></g><g data-mml-node="mo" transform="translate(1187.8,0)"><use data-c="2B" xlink:href="#MJX-1-TEX-N-2B"></use></g><g data-mml-node="msup" transform="translate(2188,0)"><g data-mml-node="mi"><use data-c="1D44F" xlink:href="#MJX-1-TEX-I-1D44F"></use></g><g data-mml-node="mn" transform="translate(462,413) scale(0.707)"><use data-c="32" xlink:href="#MJX-1-TEX-N-32"></use></g></g><g data-mml-node="mo" transform="translate(3331.3,0)"><use data-c="3D" xlink:href="#MJX-1-TEX-N-3D"></use></g><g data-mml-node="msup" transform="translate(4387.1,0)"><g data-mml-node="mi"><use data-c="1D450" xlink:href="#MJX-1-TEX-I-1D450"></use></g><g data-mml-node="mn" transform="translate(466,413) scale(0.707)"><use data-c="32" xlink:href="#MJX-1-TEX-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn:pythagorean_theorem" transform="translate(0,683)"><text data-id-align="true"></text><g data-idbox="true" transform="translate(0,-750)"><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-1-TEX-N-28"></use><use data-c="31" xlink:href="#MJX-1-TEX-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-1-TEX-N-29" transform="translate(889,0)"></use></g></g></g></g></svg></g></g></g></g></svg></mjx-container>
-<p>See equation <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 1278 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-2-TEX-N-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path><path id="MJX-2-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><a href="#mjx-eqn%3Apythagorean_theorem"><g data-mml-node="mrow" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="1000" y="-250"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-2-TEX-N-28"></use><use data-c="31" xlink:href="#MJX-2-TEX-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-2-TEX-N-29" transform="translate(889,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
-<p>Reference to an undefined equation <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.566ex;" xmlns="http://www.w3.org/2000/svg" width="4.964ex" height="2.262ex" role="img" focusable="false" viewBox="0 -750 2194 1000" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-3-TEX-N-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path><path id="MJX-3-TEX-N-3F" d="M226 668Q190 668 162 656T124 632L114 621Q116 621 119 620T130 616T145 607T157 591T162 567Q162 544 147 529T109 514T71 528T55 566Q55 625 100 661T199 704Q201 704 210 704T224 705H228Q281 705 320 692T378 656T407 612T416 567Q416 503 361 462Q267 395 247 303Q242 279 242 241V224Q242 205 239 202T222 198T205 201T202 218V249Q204 320 220 371T255 445T292 491T315 537Q317 546 317 574V587Q317 604 315 615T304 640T277 661T226 668ZM162 61Q162 89 180 105T224 121Q247 119 264 104T281 61Q281 31 264 16T222 1Q197 1 180 16T162 61Z"></path><path id="MJX-3-TEX-N-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><a href="#"><g data-mml-node="mrow" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="2194" height="1000" y="-250"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-3-TEX-N-28"></use><use data-c="3F" xlink:href="#MJX-3-TEX-N-3F" transform="translate(389,0)"></use><use data-c="3F" xlink:href="#MJX-3-TEX-N-3F" transform="translate(861,0)"></use><use data-c="3F" xlink:href="#MJX-3-TEX-N-3F" transform="translate(1333,0)"></use><use data-c="29" xlink:href="#MJX-3-TEX-N-29" transform="translate(1805,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
+<mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true" width="full" style="min-width: 21.296ex;"><svg style="vertical-align: -0.717ex; min-width: 21.296ex;" xmlns="http://www.w3.org/2000/svg" width="100%" height="2.565ex" role="img" focusable="false" xmlns:xlink="http://www.w3.org/1999/xlink" data-mjx-view-box="0 -817 9412.7 1133.9"><defs><path id="MJX-1-NCM-I-1D44E" d="M498 144C498 153 493 158 482 158C474 158 468 151 465 137C445 58 421 18 394 18C377 18 368 32 368 60C368 73 372 97 381 132L438 357C443 376 445 387 445 392C445 412 434 422 412 422C391 422 377 410 370 387C349 424 319 442 281 442C216 442 159 409 109 343C63 281 40 217 40 150C40 63 91-11 175-11C218-11 260 12 300 58C311 20 345-11 392-11C461-11 482 70 498 144M341 374C350 353 355 339 355 330C355 326 354 321 353 314L304 122C301 111 294 99 285 87C248 41 212 18 177 18C138 18 118 48 118 107C118 131 124 167 136 215C157 300 187 357 224 388C244 405 263 413 282 413C309 413 329 400 341 374Z"></path><path id="MJX-1-NCM-N-32" d="M237 666C186 666 143 648 106 612C69 576 50 534 50 483C50 449 75 424 106 424C136 424 161 450 161 480C161 513 137 536 105 536C102 536 100 536 98 535C117 584 161 627 224 627C306 627 352 556 352 470C352 403 318 331 250 255L62 43C49 28 50 29 50 0L421 0L450 180L417 180C409 129 402 100 396 91C391 86 361 84 306 84L139 84L236 179C304 243 390 312 419 365C439 400 449 435 449 470C449 588 357 666 237 666Z"></path><path id="MJX-1-NCM-N-2B" d="M698 274L413 274L413 559C413 575 405 583 389 583C373 583 365 575 365 559L365 274L80 274C64 274 56 266 56 250C56 234 64 226 80 226L365 226L365-59C365-75 373-83 389-83C405-83 413-75 413-59L413 226L698 226C714 226 722 234 722 250C722 263 711 274 698 274Z"></path><path id="MJX-1-NCM-I-1D44F" d="M281 445C245 445 209 428 174 394L243 679C241 688 238 694 226 694C193 694 120 685 107 684C92 682 84 675 84 660C84 650 93 645 112 645C131 645 157 646 157 632C157 628 152 608 143 571L63 249C52 207 47 173 47 148C47 62 93-11 175-11C240-11 297 22 347 89C392 151 415 216 415 283C415 370 364 445 281 445M279 415C318 415 337 385 337 326C337 299 331 263 319 218C297 133 268 75 233 44C213 27 194 19 175 19C134 19 114 51 114 115C114 137 119 170 129 214L151 304C154 319 159 330 165 338C204 389 242 415 279 415Z"></path><path id="MJX-1-NCM-N-3D" d="M698 367L80 367C64 367 56 359 56 344C56 329 64 321 80 321L698 321C714 321 722 329 722 344C722 356 711 367 698 367M698 179L80 179C64 179 56 171 56 156C56 141 64 133 80 133L698 133C714 133 722 141 722 156C722 169 711 179 698 179Z"></path><path id="MJX-1-NCM-I-1D450" d="M328 325C328 300 341 287 368 287C404 287 427 318 427 354C427 410 368 442 308 442C239 442 176 412 122 353C68 294 41 229 41 159C41 61 106-11 204-11C257-11 304 2 345 27C379 48 404 69 420 90C427 99 430 106 430 109C430 120 425 126 414 126C409 126 404 122 398 114C365 70 324 42 277 30C246 22 223 18 206 18C149 18 121 53 121 122C121 184 150 274 174 317C198 361 249 413 308 413C346 413 372 402 386 381C355 378 328 358 328 325Z"></path><path id="MJX-1-NCM-N-28" d="M318-248C327-248 332-243 332-234C332-231 330-227 327-223C275-183 233-117 202-26C175 53 161 131 161 208L161 292C161 369 175 447 202 526C233 617 275 683 327 723C330 726 332 730 332 734C332 743 327 748 318 748C317 748 314 747 311 745C251 699 201 631 160 540C121 453 101 371 101 292L101 208C101 129 121 47 160-40C201-131 251-199 311-245C314-247 317-248 318-248Z"></path><path id="MJX-1-NCM-N-31" d="M269 666C228 624 168 603 89 603L89 564C141 564 184 572 217 588L217 82C217 64 213 52 204 47C195 42 170 39 130 39L95 39L95 0C120 2 174 3 257 3C340 3 394 2 419 0L419 39L384 39C343 39 318 42 310 47C302 52 297 64 297 82L297 636C297 660 295 666 269 666Z"></path><path id="MJX-1-NCM-N-29" d="M78-245C138-199 188-131 229-40C268 47 288 129 288 208L288 292C288 371 268 453 229 540C188 631 138 699 78 745C75 747 72 748 71 748C62 748 57 743 57 734C57 730 59 726 62 723C114 683 156 617 187 526C214 447 228 369 228 292L228 208C228 131 214 53 187-26C156-117 114-183 62-223C59-227 57-231 57-234C57-243 62-248 71-248C72-248 75-247 78-245Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(0.0181,-0.0181) translate(0, -817)"><g data-mml-node="math" data-latex="\begin{equation}\label{pythagorean theorem}a^2 + b^2 = c^2\end{equation}"><g data-mml-node="mtable" data-latex="\begin{equation}\label{pythagorean theorem}a^2  + b^2  = c^2 \end{equation}" transform="translate(2078,0) translate(-2078,0)"><g transform="translate(0 817) matrix(1 0 0 -1 0 0) scale(55.25)"><svg data-table="true" preserveAspectRatio="xMidYMid" viewBox="2628.3 -817 1 1133.9"><g transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mlabeledtr" transform="translate(0,-67)"><g data-mml-node="mtd"><g data-mml-node="msup" data-latex="a^2"><g data-mml-node="mi" data-latex="a"><use data-c="1D44E" xlink:href="#MJX-1-NCM-I-1D44E"></use></g><g data-mml-node="mn" transform="translate(562,413) scale(0.707)" data-latex="2"><use data-c="32" xlink:href="#MJX-1-NCM-N-32"></use></g></g><g data-mml-node="mo" data-latex="+" transform="translate(1187.8,0)"><use data-c="2B" xlink:href="#MJX-1-NCM-N-2B"></use></g><g data-mml-node="msup" data-latex="b^2" transform="translate(2188,0)"><g data-mml-node="mi" data-latex="b"><use data-c="1D44F" xlink:href="#MJX-1-NCM-I-1D44F"></use></g><g data-mml-node="mn" transform="translate(462,413) scale(0.707)" data-latex="2"><use data-c="32" xlink:href="#MJX-1-NCM-N-32"></use></g></g><g data-mml-node="mo" data-latex="=" transform="translate(3331.3,0)"><use data-c="3D" xlink:href="#MJX-1-NCM-N-3D"></use></g><g data-mml-node="msup" data-latex="c^2" transform="translate(4387.1,0)"><g data-mml-node="mi" data-latex="c"><use data-c="1D450" xlink:href="#MJX-1-NCM-I-1D450"></use></g><g data-mml-node="mn" transform="translate(466,413) scale(0.707)" data-latex="2"><use data-c="32" xlink:href="#MJX-1-NCM-N-32"></use></g></g></g></g></g></svg><svg data-labels="true" preserveAspectRatio="xMaxYMid" viewBox="1278 -817 1 1133.9"><g data-labels="true" transform="matrix(1 0 0 -1 0 0)"><g data-mml-node="mtd" id="mjx-eqn:pythagorean_theorem" transform="translate(0,681)"><text data-id-align="true"></text><g data-idbox="true" transform="translate(0,-748)"><g data-mml-node="mtext" data-latex="\text{(}"><use data-c="28" xlink:href="#MJX-1-NCM-N-28"></use></g><g data-mml-node="mtext" data-latex="\text{1}" transform="translate(389,0)"><use data-c="31" xlink:href="#MJX-1-NCM-N-31"></use></g><g data-mml-node="mtext" data-latex="\text{)}" transform="translate(889,0)"><use data-c="29" xlink:href="#MJX-1-NCM-N-29"></use></g></g></g></g></svg></g></g></g></g></svg></mjx-container>
+<p>See equation <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.561ex;" xmlns="http://www.w3.org/2000/svg" width="2.891ex" height="2.253ex" role="img" focusable="false" viewBox="0 -748 1278 996" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-NCM-N-28" d="M318-248C327-248 332-243 332-234C332-231 330-227 327-223C275-183 233-117 202-26C175 53 161 131 161 208L161 292C161 369 175 447 202 526C233 617 275 683 327 723C330 726 332 730 332 734C332 743 327 748 318 748C317 748 314 747 311 745C251 699 201 631 160 540C121 453 101 371 101 292L101 208C101 129 121 47 160-40C201-131 251-199 311-245C314-247 317-248 318-248Z"></path><path id="MJX-2-NCM-N-31" d="M269 666C228 624 168 603 89 603L89 564C141 564 184 572 217 588L217 82C217 64 213 52 204 47C195 42 170 39 130 39L95 39L95 0C120 2 174 3 257 3C340 3 394 2 419 0L419 39L384 39C343 39 318 42 310 47C302 52 297 64 297 82L297 636C297 660 295 666 269 666Z"></path><path id="MJX-2-NCM-N-29" d="M78-245C138-199 188-131 229-40C268 47 288 129 288 208L288 292C288 371 268 453 229 540C188 631 138 699 78 745C75 747 72 748 71 748C62 748 57 743 57 734C57 730 59 726 62 723C114 683 156 617 187 526C214 447 228 369 228 292L228 208C228 131 214 53 187-26C156-117 114-183 62-223C59-227 57-231 57-234C57-243 62-248 71-248C72-248 75-247 78-245Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\eqref{pythagorean theorem}"><a href="#mjx-eqn%3Apythagorean_theorem"><g data-mml-node="mrow" data-latex="\eqref{pythagorean theorem}" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="1278" height="996" x="0" y="-248"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-2-NCM-N-28"></use><use data-c="31" xlink:href="#MJX-2-NCM-N-31" transform="translate(389,0)"></use><use data-c="29" xlink:href="#MJX-2-NCM-N-29" transform="translate(889,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
+<p>Reference to an undefined equation <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.561ex;" xmlns="http://www.w3.org/2000/svg" width="4.964ex" height="2.253ex" role="img" focusable="false" viewBox="0 -748 2194 996" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-3-NCM-N-28" d="M318-248C327-248 332-243 332-234C332-231 330-227 327-223C275-183 233-117 202-26C175 53 161 131 161 208L161 292C161 369 175 447 202 526C233 617 275 683 327 723C330 726 332 730 332 734C332 743 327 748 318 748C317 748 314 747 311 745C251 699 201 631 160 540C121 453 101 371 101 292L101 208C101 129 121 47 160-40C201-131 251-199 311-245C314-247 317-248 318-248Z"></path><path id="MJX-3-NCM-N-3F" d="M226 705C140 705 56 652 56 570C56 535 72 518 105 518C138 518 154 535 154 568C154 598 137 614 102 616C127 655 168 675 223 675C297 675 326 646 326 573C326 555 324 540 321 528C313 501 312 502 294 482C236 419 207 344 207 257L207 213C207 194 212 185 222 185C233 185 239 195 239 216L239 250C239 331 281 404 366 467C399 492 415 525 415 568C415 662 328 705 226 705M278 56C278 87 253 113 222 113C191 113 167 87 167 56C167 26 192 0 222 0C253 0 278 25 278 56Z"></path><path id="MJX-3-NCM-N-29" d="M78-245C138-199 188-131 229-40C268 47 288 129 288 208L288 292C288 371 268 453 229 540C188 631 138 699 78 745C75 747 72 748 71 748C62 748 57 743 57 734C57 730 59 726 62 723C114 683 156 617 187 526C214 447 228 369 228 292L228 208C228 131 214 53 187-26C156-117 114-183 62-223C59-227 57-231 57-234C57-243 62-248 71-248C72-248 75-247 78-245Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\eqref{mass-energy relation}"><a href="#"><g data-mml-node="mrow" data-latex="\eqref{mass-energy relation}" class="MathJax_ref"><rect data-hitbox="true" fill="none" stroke="none" pointer-events="all" width="2194" height="996" x="0" y="-248"></rect><g data-mml-node="mtext"><use data-c="28" xlink:href="#MJX-3-NCM-N-28"></use><use data-c="3F" xlink:href="#MJX-3-NCM-N-3F" transform="translate(389,0)"></use><use data-c="3F" xlink:href="#MJX-3-NCM-N-3F" transform="translate(861,0)"></use><use data-c="3F" xlink:href="#MJX-3-NCM-N-3F" transform="translate(1333,0)"></use><use data-c="29" xlink:href="#MJX-3-NCM-N-29" transform="translate(1805,0)"></use></g></g></a></g></g></svg></mjx-container>.</p>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -18,22 +51,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -84,9 +159,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -109,10 +184,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/fixture/markdown-code-fenced-svg.html
+++ b/packages/rehype-mathjax/test/fixture/markdown-code-fenced-svg.html
@@ -1,6 +1,40 @@
-<mjx-container class="MathJax" jax="SVG" display="true"><svg style="vertical-align: -0.489ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -441 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D6FE" d="M31 249Q11 249 11 258Q11 275 26 304T66 365T129 418T206 441Q233 441 239 440Q287 429 318 386T371 255Q385 195 385 170Q385 166 386 166L398 193Q418 244 443 300T486 391T508 430Q510 431 524 431H537Q543 425 543 422Q543 418 522 378T463 251T391 71Q385 55 378 6T357 -100Q341 -165 330 -190T303 -216Q286 -216 286 -188Q286 -138 340 32L346 51L347 69Q348 79 348 100Q348 257 291 317Q251 355 196 355Q148 355 108 329T51 260Q49 251 47 251Q45 249 31 249Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FE" xlink:href="#MJX-1-TEX-I-1D6FE"></use></g></g></g></svg></mjx-container><style>
+<mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true"><svg style="vertical-align: -0.486ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -442 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-NCM-I-1D6FE" d="M524 378C537 403 543 416 543 417C543 426 538 431 527 431C520 431 515 428 512 422C477 357 436 265 388 146C384 212 371 274 349 331C320 405 275 442 214 442C151 442 96 400 68 361C35 314 18 279 18 257C18 248 26 243 43 243L48 250C65 302 94 335 135 349C163 358 185 363 201 363C305 363 357 281 357 116C357 77 353 45 345 20C311-91 294-162 294-193C294-208 300-215 311-215C323-215 335-194 346-153C363-89 375-32 382 18C385 33 387 46 390 55C426 167 471 275 524 378Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\gamma
+"><g data-mml-node="mi" data-latex="\gamma"><use data-c="1D6FE" xlink:href="#MJX-1-NCM-I-1D6FE"></use></g></g></g></svg></mjx-container><style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -14,22 +48,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -80,9 +156,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -105,10 +181,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/fixture/markdown-svg.html
+++ b/packages/rehype-mathjax/test/fixture/markdown-svg.html
@@ -1,8 +1,41 @@
-<p>Inline math <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D6FC" d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FC" xlink:href="#MJX-1-TEX-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
+<p>Inline math <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-NCM-I-1D6FC" d="M310 442C241 442 179 412 124 353C69 294 41 229 41 159C41 61 107-11 205-11C274-11 342 16 410 69C425 16 456-11 502-11C538-11 589 27 589 63C589 72 584 76 573 76C566 76 560 72 557 64C549 43 528 18 505 18C488 18 479 50 479 115C479 129 482 140 488 147C515 180 539 218 558 260C583 314 598 354 602 380L602 384C599 391 593 394 586 394C581 393 575 385 568 371C547 299 518 237 479 186L479 236C479 352 421 442 310 442M403 211C403 152 404 116 405 103C340 46 274 18 207 18C150 18 122 53 122 122C122 180 155 288 178 324C216 383 260 413 309 413C340 413 361 401 374 377C381 365 386 353 391 342C399 319 403 258 403 211Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\alpha"><g data-mml-node="mi" data-latex="\alpha"><use data-c="1D6FC" xlink:href="#MJX-1-NCM-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="SVG" display="true"><svg style="vertical-align: -0.489ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -441 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-I-1D6FE" d="M31 249Q11 249 11 258Q11 275 26 304T66 365T129 418T206 441Q233 441 239 440Q287 429 318 386T371 255Q385 195 385 170Q385 166 386 166L398 193Q418 244 443 300T486 391T508 430Q510 431 524 431H537Q543 425 543 422Q543 418 522 378T463 251T391 71Q385 55 378 6T357 -100Q341 -165 330 -190T303 -216Q286 -216 286 -188Q286 -138 340 32L346 51L347 69Q348 79 348 100Q348 257 291 317Q251 355 196 355Q148 355 108 329T51 260Q49 251 47 251Q45 249 31 249Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FE" xlink:href="#MJX-2-TEX-I-1D6FE"></use></g></g></g></svg></mjx-container><style>
+<mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true"><svg style="vertical-align: -0.486ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -442 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-NCM-I-1D6FE" d="M524 378C537 403 543 416 543 417C543 426 538 431 527 431C520 431 515 428 512 422C477 357 436 265 388 146C384 212 371 274 349 331C320 405 275 442 214 442C151 442 96 400 68 361C35 314 18 279 18 257C18 248 26 243 43 243L48 250C65 302 94 335 135 349C163 358 185 363 201 363C305 363 357 281 357 116C357 77 353 45 345 20C311-91 294-162 294-193C294-208 300-215 311-215C323-215 335-194 346-153C363-89 375-32 382 18C385 33 387 46 390 55C426 167 471 275 524 378Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\gamma"><g data-mml-node="mi" data-latex="\gamma"><use data-c="1D6FE" xlink:href="#MJX-2-NCM-I-1D6FE"></use></g></g></g></svg></mjx-container><style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -16,22 +49,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -82,9 +157,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -107,10 +182,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/fixture/small-chtml.html
+++ b/packages/rehype-mathjax/test/fixture/small-chtml.html
@@ -1,9 +1,53 @@
-<p>Inline math <mjx-container class="MathJax" jax="CHTML"><mjx-math class="MJX-TEX"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D6FC TEX-I"></mjx-c></mjx-mi></mjx-math></mjx-container>.</p>
+<p>Inline math <mjx-container class="MathJax" jax="CHTML" overflow="overflow"><mjx-math data-latex="\alpha" class="NCM-N"><mjx-mi data-latex="\alpha"><mjx-c class="mjx-c1D6FC">𝛼</mjx-c></mjx-mi></mjx-math></mjx-container>.</p>
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="CHTML" display="true"><mjx-math display="true" style="margin-left: 0; margin-right: 0;" class="MJX-TEX"><mjx-mi class="mjx-i"><mjx-c class="mjx-c1D6FE TEX-I"></mjx-c></mjx-mi></mjx-math></mjx-container>
+<mjx-container class="MathJax" jax="CHTML" overflow="overflow" display="true"><mjx-math data-latex="\gamma" display="true" class="NCM-N"><mjx-mi data-latex="\gamma"><mjx-c class="mjx-c1D6FE">𝛾</mjx-c></mjx-mi></mjx-math></mjx-container>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="CHTML"] {
-  line-height: 0;
+  white-space: nowrap;
+}
+
+mjx-mo > mjx-c, mjx-mi > mjx-c, mjx-mn > mjx-c, mjx-ms > mjx-c, mjx-mtext > mjx-c {
+  clip-path: padding-box polygon(-1em -2px, calc(100% + 1em) -2px, calc(100% + 1em) calc(100% + 2px), -1em calc(100% + 2px));
+}
+
+mjx-stretchy-h {
+  clip-path: padding-box polygon(0 -2px, 100% -2px, 100% calc(100% + 2px), 0 calc(100% + 2px));
+}
+
+mjx-stretchy-v {
+  clip-path: padding-box polygon(-2px 0, calc(100% + 2px) 0, calc(100% + 2px) 100%, -2px 100%);
 }
 
 mjx-container [space="1"] {
@@ -102,8 +146,22 @@ mjx-row {
   display: table-row;
 }
 
-mjx-row > * {
+mjx-row > mjx-cell, mjx-row > mjx-base, mjx-row > mjx-under, mjx-row > mjx-over, mjx-row > mjx-den {
   display: table-cell;
+}
+
+mjx-container [inline-breaks] {
+  display: inline;
+}
+
+mjx-container .mjx-selected {
+  outline: 2px solid black;
+}
+
+@media (prefers-color-scheme: dark) {
+  mjx-container .mjx-selected {
+    outline: 2px solid #C8C8C8;
+  }
 }
 
 mjx-mtext {
@@ -124,10 +182,6 @@ mjx-mphantom {
   visibility: hidden;
 }
 
-_::-webkit-full-page-media, _:future, :root mjx-container {
-  will-change: opacity;
-}
-
 mjx-math {
   display: inline-block;
   text-align: left;
@@ -138,34 +192,49 @@ mjx-math {
   font-size: 100%;
   font-size-adjust: none;
   letter-spacing: normal;
-  border-collapse: collapse;
   word-wrap: normal;
   word-spacing: normal;
-  white-space: nowrap;
   direction: ltr;
   padding: 1px 0;
-}
-
-mjx-container[jax="CHTML"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
-}
-
-mjx-container[jax="CHTML"][display="true"][width="full"] {
-  display: flex;
 }
 
 mjx-container[jax="CHTML"][display="true"] mjx-math {
   padding: 0;
 }
 
-mjx-container[jax="CHTML"][justify="left"] {
-  text-align: left;
+mjx-math[breakable] {
+  display: inline;
 }
 
-mjx-container[jax="CHTML"][justify="right"] {
-  text-align: right;
+mjx-container[jax="CHTML"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-BRK !important;
+}
+
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
 }
 
 mjx-mi {
@@ -175,6 +244,8 @@ mjx-mi {
 
 mjx-c {
   display: inline-block;
+  width: 0;
+  text-align: right;
 }
 
 mjx-utext {
@@ -182,216 +253,421 @@ mjx-utext {
   padding: .75em 0 .2em 0;
 }
 
-mjx-c::before {
-  display: block;
-  width: 0;
+mjx-container[jax="CHTML"] > mjx-math.NCM-N[breakable] > * {
+  font-family: MJX-NCM-ZERO, MJX-NCM-N;
 }
 
-.MJX-TEX {
-  font-family: MJXZERO, MJXTEX;
+.NCM-N {
+  font-family: MJX-NCM-ZERO, MJX-NCM-N;
 }
 
-.TEX-B {
-  font-family: MJXZERO, MJXTEX-B;
+.NCM-B {
+  font-family: MJX-NCM-ZERO, MJX-NCM-B;
 }
 
-.TEX-I {
-  font-family: MJXZERO, MJXTEX-I;
+.NCM-I {
+  font-family: MJX-NCM-ZERO, MJX-NCM-I;
 }
 
-.TEX-MI {
-  font-family: MJXZERO, MJXTEX-MI;
+.NCM-BI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-BI;
 }
 
-.TEX-BI {
-  font-family: MJXZERO, MJXTEX-BI;
+.NCM-DS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-DS;
 }
 
-.TEX-S1 {
-  font-family: MJXZERO, MJXTEX-S1;
+.NCM-F {
+  font-family: MJX-NCM-ZERO, MJX-NCM-F;
 }
 
-.TEX-S2 {
-  font-family: MJXZERO, MJXTEX-S2;
+.NCM-FB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-FB;
 }
 
-.TEX-S3 {
-  font-family: MJXZERO, MJXTEX-S3;
+.NCM-SS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SS;
 }
 
-.TEX-S4 {
-  font-family: MJXZERO, MJXTEX-S4;
+.NCM-SSB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSB;
 }
 
-.TEX-A {
-  font-family: MJXZERO, MJXTEX-A;
+.NCM-SSI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSI;
 }
 
-.TEX-C {
-  font-family: MJXZERO, MJXTEX-C;
+.NCM-SSBI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SSBI;
 }
 
-.TEX-CB {
-  font-family: MJXZERO, MJXTEX-CB;
+.NCM-M {
+  font-family: MJX-NCM-ZERO, MJX-NCM-M;
 }
 
-.TEX-FR {
-  font-family: MJXZERO, MJXTEX-FR;
+.NCM-SO {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SO;
 }
 
-.TEX-FRB {
-  font-family: MJXZERO, MJXTEX-FRB;
+.NCM-LO {
+  font-family: MJX-NCM-ZERO, MJX-NCM-LO;
 }
 
-.TEX-SS {
-  font-family: MJXZERO, MJXTEX-SS;
+.NCM-S3 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S3;
 }
 
-.TEX-SSB {
-  font-family: MJXZERO, MJXTEX-SSB;
+.NCM-S4 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S4;
 }
 
-.TEX-SSI {
-  font-family: MJXZERO, MJXTEX-SSI;
+.NCM-S5 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S5;
 }
 
-.TEX-SC {
-  font-family: MJXZERO, MJXTEX-SC;
+.NCM-S6 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S6;
 }
 
-.TEX-T {
-  font-family: MJXZERO, MJXTEX-T;
+.NCM-S7 {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S7;
 }
 
-.TEX-V {
-  font-family: MJXZERO, MJXTEX-V;
+.NCM-MI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MI;
 }
 
-.TEX-VB {
-  font-family: MJXZERO, MJXTEX-VB;
+.NCM-C {
+  font-family: MJX-NCM-ZERO, MJX-NCM-C;
 }
 
-mjx-stretchy-v mjx-c, mjx-stretchy-h mjx-c {
-  font-family: MJXZERO, MJXTEX-S1, MJXTEX-S4, MJXTEX, MJXTEX-A ! important;
+.NCM-CB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-CB;
 }
 
-@font-face /* 0 */ {
-  font-family: MJXZERO;
-  src: url("place/to/fonts/MathJax_Zero.woff") format("woff");
+.NCM-OS {
+  font-family: MJX-NCM-ZERO, MJX-NCM-OS;
 }
 
-@font-face /* 1 */ {
-  font-family: MJXTEX;
-  src: url("place/to/fonts/MathJax_Main-Regular.woff") format("woff");
+.NCM-OB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-OB;
 }
 
-@font-face /* 2 */ {
-  font-family: MJXTEX-B;
-  src: url("place/to/fonts/MathJax_Main-Bold.woff") format("woff");
+.NCM-V {
+  font-family: MJX-NCM-ZERO, MJX-NCM-V;
 }
 
-@font-face /* 3 */ {
-  font-family: MJXTEX-I;
-  src: url("place/to/fonts/MathJax_Math-Italic.woff") format("woff");
+.NCM-LT {
+  font-family: MJX-NCM-ZERO, MJX-NCM-LT;
 }
 
-@font-face /* 4 */ {
-  font-family: MJXTEX-MI;
-  src: url("place/to/fonts/MathJax_Main-Italic.woff") format("woff");
+.NCM-RB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-RB;
 }
 
-@font-face /* 5 */ {
-  font-family: MJXTEX-BI;
-  src: url("place/to/fonts/MathJax_Math-BoldItalic.woff") format("woff");
+.NCM-EM {
+  font-family: MJX-NCM-ZERO, MJX-NCM-EM;
 }
 
-@font-face /* 6 */ {
-  font-family: MJXTEX-S1;
-  src: url("place/to/fonts/MathJax_Size1-Regular.woff") format("woff");
+.NCM-B-a {
+  font-family: MJX-NCM-ZERO, MJX-NCM-B-a;
 }
 
-@font-face /* 7 */ {
-  font-family: MJXTEX-S2;
-  src: url("place/to/fonts/MathJax_Size2-Regular.woff") format("woff");
+.NCM-U {
+  font-family: MJX-NCM-ZERO, MJX-NCM-U;
 }
 
-@font-face /* 8 */ {
-  font-family: MJXTEX-S3;
-  src: url("place/to/fonts/MathJax_Size3-Regular.woff") format("woff");
+.NCM-U-a {
+  font-family: MJX-NCM-ZERO, MJX-NCM-U-a;
 }
 
-@font-face /* 9 */ {
-  font-family: MJXTEX-S4;
-  src: url("place/to/fonts/MathJax_Size4-Regular.woff") format("woff");
+.NCM-S {
+  font-family: MJX-NCM-ZERO, MJX-NCM-S;
 }
 
-@font-face /* 10 */ {
-  font-family: MJXTEX-A;
-  src: url("place/to/fonts/MathJax_AMS-Regular.woff") format("woff");
+.NCM-SB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SB;
 }
 
-@font-face /* 11 */ {
-  font-family: MJXTEX-C;
-  src: url("place/to/fonts/MathJax_Calligraphic-Regular.woff") format("woff");
+.NCM-MM {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MM;
 }
 
-@font-face /* 12 */ {
-  font-family: MJXTEX-CB;
-  src: url("place/to/fonts/MathJax_Calligraphic-Bold.woff") format("woff");
+@font-face /* NCM-MM */ {
+  font-family: MJX-NCM-MM;
+  src: url("place/to/fonts/mjx-ncm-mm.woff2") format("woff2");
 }
 
-@font-face /* 13 */ {
-  font-family: MJXTEX-FR;
-  src: url("place/to/fonts/MathJax_Fraktur-Regular.woff") format("woff");
+.NCM-SY {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SY;
 }
 
-@font-face /* 14 */ {
-  font-family: MJXTEX-FRB;
-  src: url("place/to/fonts/MathJax_Fraktur-Bold.woff") format("woff");
+@font-face /* NCM-SY */ {
+  font-family: MJX-NCM-SY;
+  src: url("place/to/fonts/mjx-ncm-sy.woff2") format("woff2");
 }
 
-@font-face /* 15 */ {
-  font-family: MJXTEX-SS;
-  src: url("place/to/fonts/MathJax_SansSerif-Regular.woff") format("woff");
+.NCM-AR {
+  font-family: MJX-NCM-ZERO, MJX-NCM-AR;
 }
 
-@font-face /* 16 */ {
-  font-family: MJXTEX-SSB;
-  src: url("place/to/fonts/MathJax_SansSerif-Bold.woff") format("woff");
+.NCM-ARL {
+  font-family: MJX-NCM-ZERO, MJX-NCM-ARL;
 }
 
-@font-face /* 17 */ {
-  font-family: MJXTEX-SSI;
-  src: url("place/to/fonts/MathJax_SansSerif-Italic.woff") format("woff");
+@font-face /* NCM-AR */ {
+  font-family: MJX-NCM-AR;
+  src: url("place/to/fonts/mjx-ncm-ar.woff2") format("woff2");
 }
 
-@font-face /* 18 */ {
-  font-family: MJXTEX-SC;
-  src: url("place/to/fonts/MathJax_Script-Regular.woff") format("woff");
+@font-face /* NCM-ARL */ {
+  font-family: MJX-NCM-ARL;
+  src: url("place/to/fonts/mjx-ncm-arl.woff2") format("woff2");
 }
 
-@font-face /* 19 */ {
-  font-family: MJXTEX-T;
-  src: url("place/to/fonts/MathJax_Typewriter-Regular.woff") format("woff");
+.NCM-MAR {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MAR;
 }
 
-@font-face /* 20 */ {
-  font-family: MJXTEX-V;
-  src: url("place/to/fonts/MathJax_Vector-Regular.woff") format("woff");
+@font-face /* NCM-MAR */ {
+  font-family: MJX-NCM-MAR;
+  src: url("place/to/fonts/mjx-ncm-mar.woff2") format("woff2");
 }
 
-@font-face /* 21 */ {
-  font-family: MJXTEX-VB;
-  src: url("place/to/fonts/MathJax_Vector-Bold.woff") format("woff");
+.NCM-SH {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SH;
 }
 
-mjx-c.mjx-c1D6FC.TEX-I::before {
+.NCM-SHB {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHB;
+}
+
+.NCM-SHI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHI;
+}
+
+.NCM-SHBI {
+  font-family: MJX-NCM-ZERO, MJX-NCM-SHBI;
+}
+
+@font-face /* NCM-SH */ {
+  font-family: MJX-NCM-SH;
+  src: url("place/to/fonts/mjx-ncm-sh.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHB */ {
+  font-family: MJX-NCM-SHB;
+  src: url("place/to/fonts/mjx-ncm-shb.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHI */ {
+  font-family: MJX-NCM-SHI;
+  src: url("place/to/fonts/mjx-ncm-shi.woff2") format("woff2");
+}
+
+@font-face /* NCM-SHBI */ {
+  font-family: MJX-NCM-SHBI;
+  src: url("place/to/fonts/mjx-ncm-shbi.woff2") format("woff2");
+}
+
+.NCM-MSH {
+  font-family: MJX-NCM-ZERO, MJX-NCM-MSH;
+}
+
+@font-face /* NCM-MSH */ {
+  font-family: MJX-NCM-MSH;
+  src: url("place/to/fonts/mjx-ncm-msh.woff2") format("woff2");
+}
+
+.NCM-VX {
+  font-family: MJX-NCM-ZERO, MJX-NCM-VX;
+}
+
+@font-face /* NCM-VX */ {
+  font-family: MJX-NCM-VX;
+  src: url("place/to/fonts/mjx-ncm-vx.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-ZERO */ {
+  font-family: MJX-NCM-ZERO;
+  src: url("place/to/fonts/mjx-ncm-zero.woff2") format("woff2");
+}
+
+@font-face /* MJX-BRK */ {
+  font-family: MJX-BRK;
+  src: url("place/to/fonts/mjx-ncm-brk.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-N */ {
+  font-family: MJX-NCM-N;
+  src: url("place/to/fonts/mjx-ncm-n.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-B */ {
+  font-family: MJX-NCM-B;
+  src: url("place/to/fonts/mjx-ncm-b.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-I */ {
+  font-family: MJX-NCM-I;
+  src: url("place/to/fonts/mjx-ncm-i.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-BI */ {
+  font-family: MJX-NCM-BI;
+  src: url("place/to/fonts/mjx-ncm-bi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-DS */ {
+  font-family: MJX-NCM-DS;
+  src: url("place/to/fonts/mjx-ncm-ds.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-F */ {
+  font-family: MJX-NCM-F;
+  src: url("place/to/fonts/mjx-ncm-f.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-FB */ {
+  font-family: MJX-NCM-FB;
+  src: url("place/to/fonts/mjx-ncm-fb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SS */ {
+  font-family: MJX-NCM-SS;
+  src: url("place/to/fonts/mjx-ncm-ss.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSB */ {
+  font-family: MJX-NCM-SSB;
+  src: url("place/to/fonts/mjx-ncm-ssb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSI */ {
+  font-family: MJX-NCM-SSI;
+  src: url("place/to/fonts/mjx-ncm-ssi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SSBI */ {
+  font-family: MJX-NCM-SSBI;
+  src: url("place/to/fonts/mjx-ncm-ssbi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-M */ {
+  font-family: MJX-NCM-M;
+  src: url("place/to/fonts/mjx-ncm-m.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SO */ {
+  font-family: MJX-NCM-SO;
+  src: url("place/to/fonts/mjx-ncm-so.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-LO */ {
+  font-family: MJX-NCM-LO;
+  src: url("place/to/fonts/mjx-ncm-lo.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S3 */ {
+  font-family: MJX-NCM-S3;
+  src: url("place/to/fonts/mjx-ncm-s3.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S4 */ {
+  font-family: MJX-NCM-S4;
+  src: url("place/to/fonts/mjx-ncm-s4.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S5 */ {
+  font-family: MJX-NCM-S5;
+  src: url("place/to/fonts/mjx-ncm-s5.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S6 */ {
+  font-family: MJX-NCM-S6;
+  src: url("place/to/fonts/mjx-ncm-s6.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S7 */ {
+  font-family: MJX-NCM-S7;
+  src: url("place/to/fonts/mjx-ncm-s7.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-MI */ {
+  font-family: MJX-NCM-MI;
+  src: url("place/to/fonts/mjx-ncm-mi.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-C */ {
+  font-family: MJX-NCM-C;
+  src: url("place/to/fonts/mjx-ncm-c.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-CB */ {
+  font-family: MJX-NCM-CB;
+  src: url("place/to/fonts/mjx-ncm-cb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-OS */ {
+  font-family: MJX-NCM-OS;
+  src: url("place/to/fonts/mjx-ncm-os.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-OB */ {
+  font-family: MJX-NCM-OB;
+  src: url("place/to/fonts/mjx-ncm-ob.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-V */ {
+  font-family: MJX-NCM-V;
+  src: url("place/to/fonts/mjx-ncm-v.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-LT */ {
+  font-family: MJX-NCM-LT;
+  src: url("place/to/fonts/mjx-ncm-lt.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-RB */ {
+  font-family: MJX-NCM-RB;
+  src: url("place/to/fonts/mjx-ncm-rb.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-EM */ {
+  font-family: MJX-NCM-EM;
+  src: url("place/to/fonts/mjx-ncm-em.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-B-a */ {
+  font-family: MJX-NCM-B-a;
+  src: url("place/to/fonts/mjx-ncm-b-a.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-U */ {
+  font-family: MJX-NCM-U;
+  src: url("place/to/fonts/mjx-ncm-u.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-U-a */ {
+  font-family: MJX-NCM-U-a;
+  src: url("place/to/fonts/mjx-ncm-u-a.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-S */ {
+  font-family: MJX-NCM-S;
+  src: url("place/to/fonts/mjx-ncm-s.woff2") format("woff2");
+}
+
+@font-face /* MJX-NCM-SB */ {
+  font-family: MJX-NCM-SB;
+  src: url("place/to/fonts/mjx-ncm-sb.woff2") format("woff2");
+}
+
+mjx-c.mjx-c1D6FC {
   padding: 0.442em 0.64em 0.011em 0;
-  content: "\3B1";
 }
 
-mjx-c.mjx-c1D6FE.TEX-I::before {
-  padding: 0.441em 0.543em 0.216em 0;
-  content: "\3B3";
+mjx-c.mjx-c1D6FE {
+  padding: 0.442em 0.543em 0.215em 0;
 }
 </style>

--- a/packages/rehype-mathjax/test/fixture/small-svg.html
+++ b/packages/rehype-mathjax/test/fixture/small-svg.html
@@ -1,9 +1,42 @@
-<p>Inline math <mjx-container class="MathJax" jax="SVG"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-TEX-I-1D6FC" d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FC" xlink:href="#MJX-1-TEX-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
+<p>Inline math <mjx-container class="MathJax" jax="SVG" overflow="overflow"><svg style="vertical-align: -0.025ex;" xmlns="http://www.w3.org/2000/svg" width="1.448ex" height="1.025ex" role="img" focusable="false" viewBox="0 -442 640 453" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-1-NCM-I-1D6FC" d="M310 442C241 442 179 412 124 353C69 294 41 229 41 159C41 61 107-11 205-11C274-11 342 16 410 69C425 16 456-11 502-11C538-11 589 27 589 63C589 72 584 76 573 76C566 76 560 72 557 64C549 43 528 18 505 18C488 18 479 50 479 115C479 129 482 140 488 147C515 180 539 218 558 260C583 314 598 354 602 380L602 384C599 391 593 394 586 394C581 393 575 385 568 371C547 299 518 237 479 186L479 236C479 352 421 442 310 442M403 211C403 152 404 116 405 103C340 46 274 18 207 18C150 18 122 53 122 122C122 180 155 288 178 324C216 383 260 413 309 413C340 413 361 401 374 377C381 365 386 353 391 342C399 319 403 258 403 211Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\alpha"><g data-mml-node="mi" data-latex="\alpha"><use data-c="1D6FC" xlink:href="#MJX-1-NCM-I-1D6FC"></use></g></g></g></svg></mjx-container>.</p>
 <p>Block math:</p>
-<mjx-container class="MathJax" jax="SVG" display="true"><svg style="vertical-align: -0.489ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -441 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-TEX-I-1D6FE" d="M31 249Q11 249 11 258Q11 275 26 304T66 365T129 418T206 441Q233 441 239 440Q287 429 318 386T371 255Q385 195 385 170Q385 166 386 166L398 193Q418 244 443 300T486 391T508 430Q510 431 524 431H537Q543 425 543 422Q543 418 522 378T463 251T391 71Q385 55 378 6T357 -100Q341 -165 330 -190T303 -216Q286 -216 286 -188Q286 -138 340 32L346 51L347 69Q348 79 348 100Q348 257 291 317Q251 355 196 355Q148 355 108 329T51 260Q49 251 47 251Q45 249 31 249Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math"><g data-mml-node="mi"><use data-c="1D6FE" xlink:href="#MJX-2-TEX-I-1D6FE"></use></g></g></g></svg></mjx-container>
+<mjx-container class="MathJax" jax="SVG" overflow="overflow" display="true"><svg style="vertical-align: -0.486ex;" xmlns="http://www.w3.org/2000/svg" width="1.229ex" height="1.486ex" role="img" focusable="false" viewBox="0 -442 543 657" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path id="MJX-2-NCM-I-1D6FE" d="M524 378C537 403 543 416 543 417C543 426 538 431 527 431C520 431 515 428 512 422C477 357 436 265 388 146C384 212 371 274 349 331C320 405 275 442 214 442C151 442 96 400 68 361C35 314 18 279 18 257C18 248 26 243 43 243L48 250C65 302 94 335 135 349C163 358 185 363 201 363C305 363 357 281 357 116C357 77 353 45 345 20C311-91 294-162 294-193C294-208 300-215 311-215C323-215 335-194 346-153C363-89 375-32 382 18C385 33 387 46 390 55C426 167 471 275 524 378Z"></path></defs><g stroke="currentColor" fill="currentColor" stroke-width="0" transform="scale(1,-1)"><g data-mml-node="math" data-latex="\gamma"><g data-mml-node="mi" data-latex="\gamma"><use data-c="1D6FE" xlink:href="#MJX-2-NCM-I-1D6FE"></use></g></g></g></svg></mjx-container>
 <style>
+mjx-container[overflow="scroll"][display] {
+  overflow: auto clip;
+  min-width: initial !important;
+}
+
+mjx-container[overflow="truncate"][display] {
+  overflow: hidden clip;
+  min-width: initial !important;
+}
+
+mjx-container[display] {
+  display: block;
+  text-align: center;
+  justify-content: center;
+  margin: .7em 0;
+  padding: .3em 2px;
+}
+
+mjx-container[display][width="full"] {
+  display: flex;
+}
+
+mjx-container[justify="left"] {
+  text-align: left;
+  justify-content: left;
+}
+
+mjx-container[justify="right"] {
+  text-align: right;
+  justify-content: right;
+}
+
 mjx-container[jax="SVG"] {
   direction: ltr;
+  white-space: nowrap;
 }
 
 mjx-container[jax="SVG"] > svg {
@@ -17,22 +50,64 @@ mjx-container[jax="SVG"] > svg a {
   stroke: blue;
 }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
+rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+  stroke: black;
+  stroke-width: 80px;
 }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
+@media (prefers-color-scheme: dark) {
+  rect[data-sre-highlighter-added]:has(+ .mjx-selected), rect[data-sre-highlighter-bbox].mjx-selected {
+    stroke: #C8C8C8;
+  }
 }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
+mjx-container[jax="SVG"] mjx-break {
+  white-space: normal;
+  line-height: 0;
+  clip-path: rect(0 0 0 0);
+  font-family: MJX-ZERO ! important;
 }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
+mjx-break[size="0"] {
+  letter-spacing: -0.999em;
+}
+
+mjx-break[size="1"] {
+  letter-spacing: -0.889em;
+}
+
+mjx-break[size="2"] {
+  letter-spacing: -0.833em;
+}
+
+mjx-break[size="3"] {
+  letter-spacing: -0.778em;
+}
+
+mjx-break[size="4"] {
+  letter-spacing: -0.722em;
+}
+
+mjx-break[size="5"] {
+  letter-spacing: -0.667em;
+}
+
+mjx-container[jax="SVG"] mjx-break[newline]::before {
+  white-space: pre;
+  content: "\A";
+}
+
+mjx-break[newline] + svg[width="0.054ex"] {
+  margin-right: -1px;
+}
+
+mjx-break[prebreak] {
+  letter-spacing: -.999em;
+}
+
+@font-face /* zero */ {
+  font-family: MJX-ZERO;
+  src: url(data:application/x-font-woff;charset=utf-8;base64,T1RUTwAJAIAAAwAQQ0ZGIGnFMZkAAARQAAAAlE9TLzJpUWOBAAABAAAAAGBjbWFwAAwAUwAABAQAAAAsaGVhZCFRvpAAAACcAAAANmhoZWEC8AD9AAAA1AAAACRobXR4A+gAAAAABOQAAAAIbWF4cAACUAAAAAD4AAAABm5hbWVNb8+2AAABYAAAAqNwb3N0AAMAAAAABDAAAAAgAAEAAAABAABVWOu4Xw889QADA+gAAAAA3ym+2AAAAADfKb7YAAAAAAPoAAAAAAADAAIAAAAAAAAAAQAAAu79EgAAA+gAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAIAAFAAAAIAAAADA+gB9AAFAAACigK7AAAAjAKKArsAAAHfADEBAgAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAABYWFhYAEAAIAAgAu79EgAAAu4C7gAAAAEAAAAAAXcAAAAgACAAAAAAACIBngABAAAAAAAAAAEAQQABAAAAAAABAAsAAAABAAAAAAACAAcAIQABAAAAAAADABUAxgABAAAAAAAEABMANgABAAAAAAAFAAsApQABAAAAAAAGABIAbwABAAAAAAAHAAEAQQABAAAAAAAIAAEAQQABAAAAAAAJAAEAQQABAAAAAAAKAAEAQQABAAAAAAALAAEAQQABAAAAAAAMAAEAQQABAAAAAAANAAEAQQABAAAAAAAOAAEAQQABAAAAAAAQAAsAAAABAAAAAAARAAcAIQADAAEECQAAAAIAXwADAAEECQABABYACwADAAEECQACAA4AKAADAAEECQADACoA2wADAAEECQAEACYASQADAAEECQAFABYAsAADAAEECQAGACQAgQADAAEECQAHAAIAXwADAAEECQAIAAIAXwADAAEECQAJAAIAXwADAAEECQAKAAIAXwADAAEECQALAAIAXwADAAEECQAMAAIAXwADAAEECQANAAIAXwADAAEECQAOAAIAXwADAAEECQAQABYACwADAAEECQARAA4AKG1qeC1sbS16ZXJvAG0AagB4AC0AbABtAC0AegBlAHIAb1JlZ3VsYXIAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvIFJlZ3VsYXIAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcm1qeC1sbS16ZXJvUmVndWxhcgBtAGoAeAAtAGwAbQAtAHoAZQByAG8AUgBlAGcAdQBsAGEAclZlcnNpb24gMC4xAFYAZQByAHMAaQBvAG4AIAAwAC4AMSA6bWp4LWxtLXplcm8gUmVndWxhcgAgADoAbQBqAHgALQBsAG0ALQB6AGUAcgBvACAAUgBlAGcAdQBsAGEAcgAAAAABAAMAAQAAAAwABAAgAAAABAAEAAEAAAAg//8AAAAg////4QABAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAEAQABAQETbWp4LWxtLXplcm9SZWd1bGFyAAEBASf4GwD4HAL4HQP4HgSLi/mC+nwFHQAAAIYPHQAAAIkRix0AAACUEgAFAQEMHyoxNlZlcnNpb24gMC4xbWp4LWxtLXplcm8gUmVndWxhcm1qeC1sbS16ZXJvUmVndWxhcnNwYWNlAAAAAYsAAgEBAwaLDvp8DgAAAAAD6AAA) format("woff");
 }
 
 g[data-mml-node="merror"] > g {
@@ -83,9 +158,9 @@ g[data-mml-node="mtable"] > g > svg {
 
 mjx-tool > mjx-tip {
   display: inline-block;
+  line-height: 0;
   padding: .2em;
   border: 1px solid #888;
-  font-size: 70%;
   background-color: #F8F8F8;
   color: black;
   box-shadow: 2px 2px 5px #AAAAAA;
@@ -108,10 +183,58 @@ mjx-status {
   color: black;
 }
 
+g[data-mjx-collapsed] {
+  fill: #55F;
+}
+
+@media (prefers-color-scheme: dark) /* svg maction */ {
+  mjx-tool > mjx-tip {
+    background-color: #303030;
+      color: #E0E0E0;
+      box-shadow: 2px 2px 5px #000;
+  }
+  mjx-status {
+    background-color: #303030;
+      color: #E0E0E0;
+  }
+  g[data-mjx-collapsed] {
+    fill: #88F;
+  }
+}
+
 foreignObject[data-mjx-xml] {
   font-family: initial;
   line-height: normal;
   overflow: visible;
+}
+
+foreignObject[data-mjx-html] {
+  overflow: visible;
+}
+
+mjx-measure-xml {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-block;
+  line-height: normal;
+  white-space: normal;
+}
+
+mjx-html {
+  display: inline-block;
+  line-height: normal;
+  text-align: initial;
+  white-space: initial;
+}
+
+mjx-html-holder {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {

--- a/packages/rehype-mathjax/test/index.js
+++ b/packages/rehype-mathjax/test/index.js
@@ -262,22 +262,77 @@ test('rehype-mathjax', async function (t) {
     )
   })
 
-  await t.test('should catch mathjax exceptions', async function () {
-    const file = await unified()
+  await t.test(
+    'should render dynamic font characters (e.g. double-struck)',
+    async function () {
+      const value = String(
+        await unified()
+          .use(rehypeParse, {fragment: true})
+          .use(rehypeMathJaxSvg)
+          .use(rehypeStringify)
+          .process('<code class="language-math">\\mathbb{R}</code>')
+      )
+
+      // Double-struck R requires the dynamic `double-struck` font file.
+      // If it loaded correctly, the SVG output contains path data.
+      assert.match(value, /path.*d="/)
+    }
+  )
+
+  await t.test(
+    'should render undefined commands gracefully (mathjax v4)',
+    async function () {
+      const file = await unified()
+        .use(rehypeParse, {fragment: true})
+        .use(rehypeMathJaxSvg)
+        .use(rehypeStringify)
+        .process('<code class=language-math>\\a{₹}</code>.')
+
+      const value = String(file).replace(/<style>[\s\S]*<\/style>/, '')
+
+      // MathJax v4 renders undefined commands in red via noundefined,
+      // rather than throwing an exception.
+      assert.match(value, /fill="red"/)
+      assert.deepEqual(file.messages.map(String), [])
+    }
+  )
+
+  await t.test('should work with `processSync`', function () {
+    // react-markdown always uses unified's `runSync()` / `processSync()`
+    // internally, so the transform must be fully synchronous.
+    const file = unified()
       .use(rehypeParse, {fragment: true})
       .use(rehypeMathJaxSvg)
       .use(rehypeStringify)
-      .process('<code class=language-math>\\a{₹}</code>.')
+      .processSync('<code class="language-math">x</code>')
 
-    const value = String(file).replace(/<style>[\s\S]*<\/style>/, '')
+    assert.match(String(file), /mjx-container/)
+  })
+
+  await t.test('should catch renderer exceptions', async function () {
+    const {createPlugin} = await import('../lib/create-plugin.js')
+
+    const rehypeThrow = createPlugin(function () {
+      return {
+        render() {
+          throw new Error('test error')
+        }
+      }
+    })
+
+    const file = await unified()
+      .use(rehypeParse, {fragment: true})
+      .use(rehypeThrow)
+      .use(rehypeStringify)
+      .process('<code class=language-math>x</code>.')
 
     assert.equal(
-      value,
-      '<span class="mathjax-error" style="color:#cc0000" title="TypeError: Cannot read properties of null (reading &#x27;4&#x27;)">\\a{₹}</span>.'
+      String(file),
+      '<span class="mathjax-error" style="color:#cc0000" title="Error: test error">x</span>.'
     )
 
     assert.deepEqual(file.messages.map(String), [
-      '1:1-1:39: Could not render math with mathjax'
+      '1:1-1:35: Could not render math with mathjax'
     ])
   })
 })

--- a/packages/rehype-mathjax/test/index.js
+++ b/packages/rehype-mathjax/test/index.js
@@ -309,6 +309,13 @@ test('rehype-mathjax', async function (t) {
     assert.match(String(file), /mjx-container/)
   })
 
+  await t.test('should have a no-op asyncLoad', async function () {
+    const {mathjax} = await import('@mathjax/src/js/mathjax.js')
+    const result = mathjax.asyncLoad('anything')
+    assert.ok(result instanceof Promise)
+    assert.equal(await result, undefined)
+  })
+
   await t.test('should catch renderer exceptions', async function () {
     const {createPlugin} = await import('../lib/create-plugin.js')
 

--- a/packages/rehype-mathjax/test/index.js
+++ b/packages/rehype-mathjax/test/index.js
@@ -311,9 +311,8 @@ test('rehype-mathjax', async function (t) {
 
   await t.test('should have a no-op asyncLoad', async function () {
     const {mathjax} = await import('@mathjax/src/js/mathjax.js')
-    const result = mathjax.asyncLoad('anything')
-    assert.ok(result instanceof Promise)
-    assert.equal(await result, undefined)
+    assert.ok(mathjax.asyncLoad('anything') instanceof Promise)
+    assert.equal(await mathjax.asyncLoad('anything'), undefined)
   })
 
   await t.test('should catch renderer exceptions', async function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "exactOptionalPropertyTypes": true,
     "lib": ["es2022"],
     "module": "node16",
-    // To do: remove when `mathjax-full` types are fixed.
+    // To do: remove when `@mathjax/src` types are fixed.
     "skipLibCheck": true,
     "strict": true,
     "target": "es2022"


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

# Update MathJax from v3 to v4

Closes https://github.com/remarkjs/remark-math/issues/114

## Summary

Upgrades `rehype-mathjax` from `mathjax-full@^3.0.0` (MathJax v3, resolved to 3.2.1) to `@mathjax/src@^4.0.0` (MathJax v4). This is a major dependency upgrade reflecting MathJax's package rename, new font system, improved error handling, and a fundamentally different font loading architecture that required a custom preloading strategy for bundler and `runSync()` compatibility.

## Motivation

MathJax v4 was released with significant improvements:
- New Computer Modern (NCM) font replacing the legacy TeX font, with better glyph coverage
- Improved accessibility (`data-latex` attributes on SVG elements)
- Dark mode support in generated CSS
- More robust error handling (undefined TeX commands render gracefully instead of throwing)
- Line-break support in math output
- New TeX extensions: `action`, `bbm`, `bbox`, `begingroup`, `dsfont`, `texhtml`, `units`

## Breaking changes

This is a **semver-major** change for `rehype-mathjax`:

- **Output differs**: All rendered SVG and CHTML output changes (font IDs, path data, CSS classes, accessibility attributes). Snapshot tests downstream will need updating.
- **Font changed**: TeX font → New Computer Modern (NCM). Glyph metrics differ slightly; visual output is similar but not pixel-identical.
- **CHTML `fontURL` changed**: Must now point to `@mathjax/mathjax-newcm-font/chtml/woff2` instead of `mathjax@3/es5/output/chtml/fonts/woff-v2`.
- **Error behavior changed**: Undefined TeX commands (e.g., `\foo`) now render as red text inline instead of throwing. The catch-block fallback still works for actual renderer exceptions.

## Design decisions

### Why static font imports instead of dynamic loaders

MathJax v4 fundamentally changed its font architecture. In v3, all font data was bundled into the output constructors. In v4, font data is split into 40 "dynamic" files per output format (SVG/CHTML) that are loaded on-demand at runtime via `mathjax.asyncLoad()`.

MathJax v4 provides two built-in loaders for this:

1. **Sync Node.js loader** (`require.mjs` + `asyncLoad/node.js`): Uses `createRequire` from the `module` builtin to synchronously `require()` font files. This works in plain Node.js but **crashes in bundlers** (webpack, Vite, Next.js, esbuild, Turbopack) with `createRequire is not a function` because bundlers don't provide the `module` builtin.

2. **Async ESM loader** (`asyncLoad/esm.js`): Uses dynamic `import()` to load font files on demand. When `document.convert()` encounters an unloaded glyph, MathJax's retry mechanism throws a synchronous Error with a `.retry` promise, caught by `handleRetriesFor()` which awaits the font load and retries. This has two problems:
   - **Breaks `runSync()`**: The transform must be `async` to use `handleRetriesFor()`. Libraries like `react-markdown` use unified's `runSync()` internally, which throws if any transform returns a Promise.
   - **Breaks bundlers**: The `import()` call receives a runtime-computed string (built inside MathJax's `dynamicFileName()`: `prefix + '/' + file + '.js'`). Bundlers cannot statically analyze this — webpack emits "Critical dependency: the request of a dependency is an expression" and Vite/Rollup silently fail to resolve the paths.

**Our approach**: Statically import all font data files from `@mathjax/mathjax-newcm-font` at build time. Each file calls `dynamicSetup()` on the font class as a side effect, registering glyph data at import time. We set `mathjax.asyncLoad` to a no-op since nothing needs runtime loading. The transform stays fully synchronous.

Font imports are split per output format and trimmed to math-essential files only (12 of 40). Extended scripts (Cyrillic, Arabic, Hebrew, Braille, Cherokee, Devanagari, etc.) and extra font variants (sans-serif, monospace, phonetics, extended Latin/Greek) are omitted to keep the SVG bundle close to v3's ~1 MB:

- **`lib/svg.js`**: 12 SVG font files (~1.1 MB) — accents, arrows, calligraphic, double-struck, fraktur, marrows, math, mshapes, script, shapes, symbols, variants
- **`lib/chtml.js`**: 12 CHTML font files (~113 KB) — same set

### Why per-instance `setup(font)` in `register()`

MathJax's `dynamicSetup()` (called by the static font imports) registers `setup` functions on the **class-level** `dynamicFiles` object. These functions populate a font instance with character data when called with `setup(font)`.

MathJax's `loadDynamicFiles()` and `loadDynamicFileSync()` both have a class-level `if (!dynamic.promise)` guard: once a file is marked as loaded for the class, subsequent calls skip `setup()` entirely. This means new font instances (created on each `register()` call) never get populated.

We work around this by explicitly iterating `dynamicFiles` in `register()` and calling `df.setup(font)` for each entry. The `df.promise ??= Promise.resolve()` ensures MathJax's internal tracking considers the file loaded (preventing any attempted runtime load via the no-op `asyncLoad`).

### Bundle size impact

Measured with esbuild (`--bundle --platform=node`), comparing the v3 (`mathjax-full@3.2.1`) and v4 (`@mathjax/src@4.1.1`) bundles:

**SVG entry (`rehype-mathjax/svg`):**

| | v3 | v4 | Change |
|---|---|---|---|
| **Output bundle** | **2.6 MB** | **3.1 MB** | **+19%** |
| Font data | 998 KB | 2.1 MB | +1.1 MB |
| TeX extensions | 532 KB | 471 KB | -61 KB |
| MathJax core | 874 KB | 578 KB | -296 KB |

**CHTML entry (`rehype-mathjax/chtml`):**

| | v3 | v4 | Change |
|---|---|---|---|
| **Output bundle** | **1.7 MB** | **1.3 MB** | **-24%** |
| Font data | 56 KB | 282 KB | +226 KB |
| TeX extensions | 532 KB | 471 KB | -61 KB |
| MathJax core | 898 KB | 604 KB | -294 KB |

**Why SVG is +19%**: MathJax v4's core engine and TeX extensions are smaller than v3 (-300 KB combined), but the font architecture changed. In v3, all font data was bundled in a single 998 KB blob inside the SVG output class. In v4, the base font was split into a 1,021 KB static class plus 40 on-demand "dynamic" files. We import 12 math-essential dynamic files (~1 MB), which together with the static class totals ~2 MB — roughly double v3's font cost. The core savings partially offset this.

**Why CHTML is -24%**: Same core savings (-270 KB), but CHTML dynamic files store only numeric metrics (not SVG paths), so the 12 files add just 113 KB — far less than the core reduction.

MathJax v4 provides 40 dynamic font files per format (totaling ~9.9 MB for SVG). We import only the **12 math-essential** files, keeping the SVG bundle at 3.1 MB. The omitted 28 files contain extended scripts and font variants:

| Omitted category | Files | SVG size |
|-------------------|-------|----------|
| Extended scripts (Cyrillic, Arabic, Hebrew, Braille, Cherokee, Devanagari) | 10 | 2.2 MB |
| Extended Latin/Greek variants (italic, bold, bold-italic, sans-serif) | 12 | 5.3 MB |
| Monospace/phonetics/PUA | 6 | 1.4 MB |

**Included** (math-essential): accents, arrows, calligraphic (`\mathcal`), double-struck (`\mathbb`), fraktur (`\mathfrak`), marrows, math, mshapes, script (`\mathscr`), shapes, symbols, variants.

Characters in omitted files that are encountered at runtime will trigger a MathJax retry error (rendered as a red `<span class="mathjax-error">`). Users needing extended scripts can add the imports in a custom plugin.

### Why `sideEffects` array instead of `false`

The original package.json had `"sideEffects": false`. This is incorrect now because `lib/svg.js`, `lib/chtml.js`, `lib/tex-packages.js`, and `lib/create-renderer.js` all have side-effect imports (font data registration, TeX extension registration, `mathjax.asyncLoad` assignment). While most bundlers handle this correctly for actively-used modules, the explicit array is defensive and documents the intent.

### TeX package audit

MathJax v4 ships 42 TeX extensions. We include 40, matching v3's `AllPackages` plus new v4 extensions. Two are excluded:

| Excluded | Reason |
|----------|--------|
| `autoload` | Loads extensions on-demand via `asyncLoad`, which requires the async runtime loader — incompatible with our synchronous preloading approach. |
| `bboldx` | Requires a `-bboldx` font variant not present in the NCM font package (produces `Invalid variant` warnings at runtime). |

New v4 packages not in v3's `AllPackages`: `action` (tooltips), `bbm` (blackboard bold), `bbox` (bounding boxes), `begingroup` (TeX grouping), `dsfont` (double-struck), `texhtml` (HTML in TeX), `units` (unit formatting).

Known command overrides (same behavior as v3):
- `physics` redefines `\div`, `\Re`, `\Im`, and trig/log functions — included to match v3
- `colorv2` overrides `\color` from the `color` package — included to match v3
- `ams` enhances `\frac` and `\boxed` from `base` (standard LaTeX behavior)
- `mathtools` enhances `\shoveleft`/`\shoveright` from `ams`

## Changes

### Dependency changes (`package.json`)

| Before | After |
|--------|-------|
| `mathjax-full: ^3.0.0` | `@mathjax/src: ^4.0.0` |
| `@types/mathjax: ^0.0.40` | _(removed — no v4-compatible types)_ |
| _(none)_ | `@mathjax/mathjax-newcm-font: ^4.0.0` |
| `"sideEffects": false` | `"sideEffects": ["./lib/svg.js", "./lib/chtml.js", "./lib/tex-packages.js", "./lib/create-renderer.js"]` |

Added `"import/no-unassigned-import": "off"` to XO lint config to allow the side-effect imports required by v4.

### Code organization

| Module | Responsibility |
|--------|---------------|
| `lib/tex-packages.js` _(new)_ | 40 TeX extension side-effect imports + exported `allPackages` array (shared by SVG and CHTML) |
| `lib/svg.js` | 12 SVG font side-effect imports (~1.1 MB) + SVG plugin entry point |
| `lib/chtml.js` | 12 CHTML font side-effect imports (~113 KB) + CHTML plugin entry point |
| `lib/create-renderer.js` | `mathjax.asyncLoad` no-op, renderer factory with per-instance font setup loop, `fromLiteElement` hast converter |
| `lib/create-plugin.js` | rehype plugin framework, visitor pattern, error catch block _(logic unchanged)_ |

### Import path migration

All imports updated from `mathjax-full/js/...` to `@mathjax/src/js/...`. MathJax v4 renamed the npm package but kept the same internal module structure, so the paths after the package name are unchanged.

### Documentation update (`create-plugin.js`)

Updated the CHTML `fontURL` example in JSDoc from `mathjax@3/es5/output/chtml/fonts/woff-v2` to `@mathjax/mathjax-newcm-font/chtml/woff2` to reflect v4's new font package.

### Error handling behavior change

MathJax v4's `noundefined` package now renders undefined TeX commands as red text inline (e.g., `\a` renders as red `\a` in the SVG) instead of throwing a `TypeError`. This is a user-visible improvement — malformed LaTeX degrades gracefully instead of crashing.

The error handling test was split into two:

1. **"should render undefined commands gracefully (mathjax v4)"** — Verifies that `\a{₹}` (which threw in v3) now renders with `fill="red"` and produces no `file.messages`.

2. **"should catch renderer exceptions"** — Tests the catch-block safety net using a custom renderer that throws, verifying the `<span class="mathjax-error">` fallback still works.

### New tests

- **"should render dynamic font characters (e.g. double-struck)"** — Verifies `\mathbb{R}` renders correctly, testing that the static font preloading works for characters outside the base font range (these are in the dynamic font files, not the static base font).

- **"should work with `processSync`"** — Verifies the transform works synchronously with `processSync()` / `runSync()`, which `react-markdown` always uses internally. This is the key compatibility constraint that prevents using async dynamic loaders.

### Test fixture regeneration

All 9 SVG/CHTML fixture files were regenerated. The output differences are:

| Change | Reason |
|--------|--------|
| Font IDs `MJX-*-TEX-*` → `MJX-*-NCM-*` | Default font changed from Computer Modern to New Computer Modern |
| Different SVG `<path>` data | New font glyphs |
| New `overflow="overflow"` attribute on `<mjx-container>` | v4 overflow handling feature |
| New `data-latex="..."` attributes on SVG `<g>` elements | v4 accessibility / debugging |
| CHTML class `MJX-TEX` → `NCM-N` | New font family identifier |
| CHTML elements contain Unicode characters (e.g., `𝛼`) | v4 embeds actual characters instead of CSS content |
| CHTML fonts: woff → woff2, `MJXTEX-*` → `NCM-*` families | New font format and naming |
| Minor viewBox / vertical-align metric changes | Slightly different glyph metrics in NCM |
| Expanded CSS (dark mode, line breaks, `mjx-break`, `MJX-ZERO` font) | v4 feature additions |

Browser variant fixtures (`small-browser.html`, `small-browser-delimiters.html`) are **unchanged** since that variant wraps math for client-side MathJax rather than rendering server-side.

## Files modified

- `packages/rehype-mathjax/package.json` — dependencies, sideEffects, lint config
- `packages/rehype-mathjax/lib/tex-packages.js` _(new)_ — TeX extension imports + allPackages
- `packages/rehype-mathjax/lib/create-renderer.js` — asyncLoad no-op, renderer with font setup
- `packages/rehype-mathjax/lib/create-plugin.js` — fontURL docs update
- `packages/rehype-mathjax/lib/svg.js` — 40 SVG font imports + plugin entry
- `packages/rehype-mathjax/lib/chtml.js` — 40 CHTML font imports + plugin entry
- `packages/rehype-mathjax/test/index.js` — 3 new tests, 1 split test
- `packages/rehype-mathjax/test/fixture/*.html` — 9 regenerated SVG/CHTML fixtures

## Verification

- All 22 `rehype-mathjax` tests pass (including 3 new tests)
- `remark-math` tests pass (53/53)
- `processSync()` works (verifies `runSync()` / `react-markdown` compatibility)
- Dynamic font characters (`\mathbb{R}`) render correctly via static preloading
- No `createRequire is not a function` crash in bundled environments
- No `Invalid variant` warnings at runtime
- `rehype-katex` has 1 pre-existing failure unrelated to this change (Node.js version compatibility with `vfile` message properties)

Before usage in production environment
<img width="1491" height="1170" alt="image" src="https://github.com/user-attachments/assets/89d32e4d-918c-4807-9f4d-ac37b42a6a9e" />
After
<img width="1462" height="1169" alt="image" src="https://github.com/user-attachments/assets/2be2b592-c7f6-48f9-842b-dc11a3d2e21c" />
